### PR TITLE
Add CD workflow to build and release AppImages for x86_64 and aarch64

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -42,7 +42,7 @@ jobs:
         build: [x86_64-linux, aarch64-linux]
         include:
           - build: x86_64-linux
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
             rust_target: x86_64-unknown-linux-gnu
             appimage_tool: appimagetool-x86_64.AppImage
             lib_path: /lib/x86_64-linux-gnu
@@ -51,7 +51,7 @@ jobs:
             ld_linux: /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
             ld_name: ld-linux-x86-64.so.2
           - build: aarch64-linux
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
             rust_target: aarch64-unknown-linux-gnu
             appimage_tool: appimagetool-aarch64.AppImage
             lib_path: /lib/aarch64-linux-gnu

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -108,7 +108,6 @@ jobs:
           # Copy the dynamic linker
           cp -L ${{ matrix.ld_linux }} AppDir/usr/lib/${{ matrix.ld_name }}
           # Copy glibc and other required libraries
-          cp -L ${{ matrix.lib_path }}/libstdc++.so.6 AppDir/usr/lib/
           cp -L ${{ matrix.lib_path }}/libc.so.6 AppDir/usr/lib/
           cp -L ${{ matrix.lib_path }}/libm.so.6 AppDir/usr/lib/
           cp -L ${{ matrix.lib_path }}/libdl.so.2 AppDir/usr/lib/

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,0 +1,169 @@
+# Copyright 2021- Dotan Nahum
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is modified by Mrmayman, ApicalShark on 2024
+# This file is modified by Sreehari425 on 2025
+
+name: Release AppImages
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch: # Allows manual triggering
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+env:
+  BIN_NAME: quantum_launcher
+  PROJECT_NAME: quantum_launcher
+  CARGO_TERM_COLOR: always
+
+jobs:
+  dist:
+    name: Build AppImage
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [x86_64-linux, aarch64-linux]
+        include:
+          - build: x86_64-linux
+            runner: ubuntu-24.04
+            rust_target: x86_64-unknown-linux-gnu
+            appimage_tool: appimagetool-x86_64.AppImage
+            lib_path: /lib/x86_64-linux-gnu
+            appimage_arch: x86_64
+            cross: false
+            ld_linux: /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+            ld_name: ld-linux-x86-64.so.2
+          - build: aarch64-linux
+            runner: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+            appimage_tool: appimagetool-aarch64.AppImage
+            lib_path: /lib/aarch64-linux-gnu
+            appimage_arch: arm_aarch64
+            cross: false
+            ld_linux: /lib/aarch64-linux-gnu/ld-linux-aarch64.so.1
+            ld_name: ld-linux-aarch64.so.1
+
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config libdbus-1-3 libfuse2 wget
+          if [ "${{ matrix.cross }}" == "true" ]; then
+            sudo apt-get install -y gcc-arm-linux-gnueabihf libc6-dev-armhf-cross
+          fi
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.rust_target }}
+          override: true
+
+      - name: Install cross for armv7
+        if: matrix.cross
+        run: cargo install cross --locked
+
+      - name: Build binary
+        run: |
+          if [ "${{ matrix.cross }}" == "true" ]; then
+            cross build --release --target ${{ matrix.rust_target }}
+          else
+            cargo build --release --target ${{ matrix.rust_target }}
+          fi
+
+      - name: Prepare AppDir
+        run: |
+          mkdir -p AppDir/usr/bin AppDir/usr/lib AppDir/usr/share/applications AppDir/usr/share/icons/hicolor/256x256/apps
+          cp target/${{ matrix.rust_target }}/release/${{ env.BIN_NAME }} AppDir/usr/bin/
+          cp assets/appimage/quantum-launcher.desktop AppDir/usr/share/applications/quantum-launcher.desktop
+          cp assets/appimage/quantum-launcher.desktop AppDir/quantum-launcher.desktop
+          cp AppDir/usr/share/applications/quantum-launcher.desktop AppDir/quantum-launcher.desktop
+          # Replace 'path/to/your/icon.png' with the actual path to your icon in the repository
+          cp assets/icon/256x256/ql_logo.png AppDir/usr/share/icons/hicolor/256x256/apps/quantum-launcher.png
+          cp assets/icon/256x256/ql_logo.png AppDir/quantum-launcher.png
+          # Copy the dynamic linker
+          cp -L ${{ matrix.ld_linux }} AppDir/usr/lib/${{ matrix.ld_name }}
+          # Copy glibc and other required libraries
+          cp -L ${{ matrix.lib_path }}/libc.so.6 AppDir/usr/lib/
+          cp -L ${{ matrix.lib_path }}/libm.so.6 AppDir/usr/lib/
+          cp -L ${{ matrix.lib_path }}/libdl.so.2 AppDir/usr/lib/
+          cp -L ${{ matrix.lib_path }}/libpthread.so.0 AppDir/usr/lib/
+          cp -L ${{ matrix.lib_path }}/librt.so.1 AppDir/usr/lib/
+          cp -L ${{ matrix.lib_path }}/libgcc_s.so.1 AppDir/usr/lib/
+          cp -L ${{ matrix.lib_path }}/libdbus-1.so.3 AppDir/usr/lib/
+          # Create AppRun to use bundled dynamic linker and libraries
+          echo '#!/bin/sh
+          APPDIR=$(dirname "$0")
+          exec $APPDIR/usr/lib/${{ matrix.ld_name }} --library-path $APPDIR/usr/lib $APPDIR/usr/bin/${{ env.BIN_NAME }} "$@"' > AppDir/AppRun
+          chmod +x AppDir/AppRun
+
+      - name: Download appimagetool
+        run: |
+          wget https://github.com/AppImage/AppImageKit/releases/download/13/${{ matrix.appimage_tool }}
+          chmod +x ${{ matrix.appimage_tool }}
+
+      - name: Build AppImage
+        run: |
+          ARCH=${{ matrix.appimage_arch }} ./${{ matrix.appimage_tool }} AppDir ${{ env.PROJECT_NAME }}-${{ matrix.build }}.AppImage
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PROJECT_NAME }}-${{ matrix.build }}
+          path: ${{ env.PROJECT_NAME }}-${{ matrix.build }}.AppImage
+
+  publish:
+    name: Publish
+    needs: [dist]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Calculate tag name
+        id: tagname
+        run: |
+          name=dev
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            name=${GITHUB_REF:10}
+          fi
+          echo "val=$name" >> $GITHUB_OUTPUT
+          echo "TAG=$name" >> $GITHUB_ENV
+
+      - name: Upload to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: artifacts/*/*.AppImage
+          file_glob: true
+          tag: ${{ steps.tagname.outputs.val }}
+          overwrite: true

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -109,6 +109,7 @@ jobs:
           cp -L ${{ matrix.ld_linux }} AppDir/usr/lib/${{ matrix.ld_name }}
           # Copy glibc and other required libraries
           cp -L ${{ matrix.lib_path }}/libc.so.6 AppDir/usr/lib/
+          cp -L ${{ matrix.lib_path }}/libstdc++.so.6 AppDir/usr/lib/
           cp -L ${{ matrix.lib_path }}/libm.so.6 AppDir/usr/lib/
           cp -L ${{ matrix.lib_path }}/libdl.so.2 AppDir/usr/lib/
           cp -L ${{ matrix.lib_path }}/libpthread.so.0 AppDir/usr/lib/

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -159,12 +159,9 @@ jobs:
           echo "val=$name" >> $GITHUB_OUTPUT
           echo "TAG=$name" >> $GITHUB_ENV
 
-      - name: Upload to release
+      - name: Upload to GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v4
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: artifacts/*/*.AppImage
-          file_glob: true
-          tag: ${{ steps.tagname.outputs.val }}
-          overwrite: true
+          tag_name: ${{ steps.tagname.outputs.tag_value }} # Changed from .val to .tag_value
+          files: artifacts/*/*.AppImage

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -42,7 +42,7 @@ jobs:
         build: [x86_64-linux, aarch64-linux]
         include:
           - build: x86_64-linux
-            runner: ubuntu-24.04
+            runner: ubuntu-22.04
             rust_target: x86_64-unknown-linux-gnu
             appimage_tool: appimagetool-x86_64.AppImage
             lib_path: /lib/x86_64-linux-gnu
@@ -51,7 +51,7 @@ jobs:
             ld_linux: /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
             ld_name: ld-linux-x86-64.so.2
           - build: aarch64-linux
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
             rust_target: aarch64-unknown-linux-gnu
             appimage_tool: appimagetool-aarch64.AppImage
             lib_path: /lib/aarch64-linux-gnu

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -76,11 +76,12 @@ jobs:
           fi
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.rust_target }}
-          override: true
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          source $HOME/.cargo/env
+          rustup default stable
+          rustup target add ${{ matrix.rust_target }}
+
 
       - name: Install cross for armv7
         if: matrix.cross

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -107,6 +107,7 @@ jobs:
           # Copy the dynamic linker
           cp -L ${{ matrix.ld_linux }} AppDir/usr/lib/${{ matrix.ld_name }}
           # Copy glibc and other required libraries
+          cp -L ${{ matrix.lib_path }}/libstdc++.so.6 AppDir/usr/lib/
           cp -L ${{ matrix.lib_path }}/libc.so.6 AppDir/usr/lib/
           cp -L ${{ matrix.lib_path }}/libm.so.6 AppDir/usr/lib/
           cp -L ${{ matrix.lib_path }}/libdl.so.2 AppDir/usr/lib/

--- a/assets/appimage/quantum-launcher.desktop
+++ b/assets/appimage/quantum-launcher.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=Quantum Launcher
+Comment=A simple, powerful Minecraft launcher
+Exec=quantum-launcher
+Icon=quantum-launcher
+Categories=Game;
+Terminal=false


### PR DESCRIPTION
### Summary

This PR adds a GitHub Actions workflow for **Continuous Delivery** (CD) to build and release AppImages for:

- `x86_64` (standard Linux desktops)
- `aarch64` (ARM64-based devices)

### Key Features

- Supports **manual dispatch** and automatic **tag-triggered builds** (e.g. `v1.2.3`)
- Uses **Ubuntu 22.04 runners** to build for both architectures
- **Partially bundles key runtime libraries** (`libc.so.6`, `libstdc++.so.6`, etc.) and the dynamic linker (`ld-linux`) to improve compatibility
- Builds are packaged into portable `.AppImage` files and uploaded:
  - as GitHub Actions artifacts
  - and to GitHub Releases (on tag)

### Notes

- Does **not bundle full glibc**, but includes essential runtime components.
- Still relies on the host system for some compatibility, so glibc versions may affect runtime behavior.