### PR TITLE
Fix window resize lagging on Wayland

### DIFF
--- a/quantum_launcher/src/main.rs
+++ b/quantum_launcher/src/main.rs
@@ -177,6 +177,7 @@ fn main() {
         .settings(Settings {
             fonts: load_fonts(),
             default_font: iced::Font::with_name("Inter"),
+            antialiasing: true,
             ..Default::default()
         })
         .window(iced::window::Settings {


### PR DESCRIPTION
This PR addresses a lag issue when resizing Iced windows on Wayland.

Setting `antialiasing: true` in `iced::settings::Settings` serves as a [workaround](https://discourse.iced.rs/t/why-do-lags-occur-during-resize/107/3) for an Iced bug (iced-rs/iced#2750).

Before: [video](https://github.com/user-attachments/assets/61401706-2262-4066-9c45-a42871b786b0)

After: [video](https://github.com/user-attachments/assets/07cc0401-1d8c-48d7-849d-41fb738ba771)



