### PR TITLE
dev: added window resizing to presist accross launches

### DIFF
--- a/quantum_launcher/src/config.rs
+++ b/quantum_launcher/src/config.rs
@@ -90,6 +90,14 @@ pub struct LauncherConfig {
     /// Default: `true`
     // Since: v0.4.2
     pub antialiasing: Option<bool>,
+
+    /// The width of the window when the launcher was last closed.
+    /// Used to restore the window size between launches.
+    pub window_width: Option<f32>,
+
+    /// The height of the window when the launcher was last closed.
+    /// Used to restore the window size between launches.
+    pub window_height: Option<f32>,
 }
 
 impl Default for LauncherConfig {
@@ -106,6 +114,8 @@ impl Default for LauncherConfig {
             java_installs: Some(Vec::new()),
             antialiasing: Some(true),
             account_selected: None,
+            window_width: None,
+            window_height: None,
         }
     }
 }

--- a/quantum_launcher/src/main.rs
+++ b/quantum_launcher/src/main.rs
@@ -188,8 +188,16 @@ fn main() {
             icon,
             exit_on_close_request: false,
             size: iced::Size {
-                width: WINDOW_WIDTH * scale,
-                height: WINDOW_HEIGHT * scale,
+                width: config
+                    .as_ref()
+                    .ok()
+                    .and_then(|c| c.window_width)
+                    .unwrap_or(WINDOW_WIDTH * scale),
+                height: config
+                    .as_ref()
+                    .ok()
+                    .and_then(|c| c.window_height)
+                    .unwrap_or(WINDOW_HEIGHT * scale),
             },
             min_size: Some(iced::Size {
                 width: 420.0,

--- a/quantum_launcher/src/message_handler/iced_event.rs
+++ b/quantum_launcher/src/message_handler/iced_event.rs
@@ -41,6 +41,9 @@ impl Launcher {
                 }
                 iced::window::Event::Resized(size) => {
                     self.window_size = (size.width, size.height);
+                    // Save window size to config for persistence
+                    self.config.window_width = Some(size.width);
+                    self.config.window_height = Some(size.height);
                 }
                 iced::window::Event::FileHovered(_) => {
                     self.set_drag_and_drop_hover(true);

--- a/quantum_launcher/src/state/mod.rs
+++ b/quantum_launcher/src/state/mod.rs
@@ -161,6 +161,9 @@ impl Launcher {
                 .unwrap_or_else(|| OFFLINE_ACCOUNT_NAME.to_owned()),
         );
 
+        let window_width = config.window_width.unwrap_or(WINDOW_WIDTH);
+        let window_height = config.window_height.unwrap_or(WINDOW_HEIGHT);
+
         Ok(Self {
             client_list: None,
             server_list: None,
@@ -180,7 +183,7 @@ impl Launcher {
             server_processes: HashMap::new(),
             server_logs: HashMap::new(),
             mouse_pos: (0.0, 0.0),
-            window_size: (WINDOW_WIDTH, WINDOW_HEIGHT),
+            window_size: (window_width, window_height),
             accounts,
             accounts_dropdown,
             accounts_selected: Some(selected_account),
@@ -213,6 +216,9 @@ impl Launcher {
             })
             .unwrap_or((LauncherConfig::default(), LauncherTheme::default()));
 
+        let window_width = config.window_width.unwrap_or(WINDOW_WIDTH);
+        let window_height = config.window_height.unwrap_or(WINDOW_HEIGHT);
+
         Self {
             state: State::Error { error },
             is_log_open: false,
@@ -232,7 +238,7 @@ impl Launcher {
             server_logs: HashMap::new(),
             server_version_list_cache: None,
             mouse_pos: (0.0, 0.0),
-            window_size: (WINDOW_WIDTH, WINDOW_HEIGHT),
+            window_size: (window_width, window_height),
             accounts: HashMap::new(),
             accounts_dropdown: vec![OFFLINE_ACCOUNT_NAME.to_owned(), NEW_ACCOUNT_NAME.to_owned()],
             accounts_selected: Some(OFFLINE_ACCOUNT_NAME.to_owned()),


### PR DESCRIPTION
# Add feature to remember window size between launches

This PR implements the feature requested in issue #55 to remember the custom window size between launcher sessions.

- Saves the window size on close  
- Restores the saved size on the next launch  


Closes #55