### PR TITLE
Add feature to manually set the game's window size

### DIFF
--- a/crates/ql_core/src/json/instance_config.rs
+++ b/crates/ql_core/src/json/instance_config.rs
@@ -117,6 +117,38 @@ pub struct InstanceConfigJson {
     ///
     /// Ultimately if you want one less icon in your taskbar then go ahead.
     pub close_on_start: Option<bool>,
+    /// **Client Only**
+    ///
+    /// Custom window width for Minecraft.
+    ///
+    /// **Default: `None` (uses Minecraft's default)**
+    ///
+    /// When set, this will launch Minecraft with a specific window width
+    /// using the `--width` command line argument.
+    ///
+    /// This is useful for:
+    /// - Setting a specific resolution for consistent gameplay
+    /// - Matching your monitor's resolution
+    /// - Creating smaller windows for recording/streaming
+    ///
+    /// Note: This only affects windowed mode, not fullscreen.
+    pub window_width: Option<u32>,
+    /// **Client Only**
+    ///
+    /// Custom window height for Minecraft.
+    ///
+    /// **Default: `None` (uses Minecraft's default)**
+    ///
+    /// When set, this will launch Minecraft with a specific window height
+    /// using the `--height` command line argument.
+    ///
+    /// This is useful for:
+    /// - Setting a specific resolution for consistent gameplay
+    /// - Matching your monitor's resolution
+    /// - Creating smaller windows for recording/streaming
+    ///
+    /// Note: This only affects windowed mode, not fullscreen.
+    pub window_height: Option<u32>,
 }
 
 impl InstanceConfigJson {

--- a/crates/ql_instances/src/download/downloader.rs
+++ b/crates/ql_instances/src/download/downloader.rs
@@ -321,6 +321,8 @@ impl GameDownloader {
             close_on_start: None,
             is_server: Some(false),
             omniarchive: None,
+            window_width: None,
+            window_height: None,
         };
         let config_json = serde_json::to_string(&config_json).json_to()?;
 

--- a/crates/ql_instances/src/instance/launch/launcher.rs
+++ b/crates/ql_instances/src/instance/launch/launcher.rs
@@ -45,6 +45,11 @@ pub struct GameLauncher {
 
     pub config_json: InstanceConfigJson,
     pub version_json: VersionDetails,
+
+    /// Global default window width from launcher settings
+    global_default_width: Option<u32>,
+    /// Global default window height from launcher settings
+    global_default_height: Option<u32>,
 }
 
 impl GameLauncher {
@@ -74,7 +79,15 @@ impl GameLauncher {
             minecraft_dir,
             config_json,
             version_json,
+            global_default_width: None,
+            global_default_height: None,
         })
+    }
+
+    /// Set global default resolution values from launcher settings
+    pub fn set_global_defaults(&mut self, width: Option<u32>, height: Option<u32>) {
+        self.global_default_width = width;
+        self.global_default_height = height;
     }
 
     pub fn init_game_arguments(
@@ -122,11 +135,15 @@ impl GameLauncher {
         }
 
         // Add custom resolution arguments if specified
-        if let Some(width) = self.config_json.window_width {
+        // Priority: Instance-specific setting > Global default > Minecraft default
+        let width_to_use = self.config_json.window_width.or(self.global_default_width);
+        let height_to_use = self.config_json.window_height.or(self.global_default_height);
+
+        if let Some(width) = width_to_use {
             game_arguments.push("--width".to_owned());
             game_arguments.push(width.to_string());
         }
-        if let Some(height) = self.config_json.window_height {
+        if let Some(height) = height_to_use {
             game_arguments.push("--height".to_owned());
             game_arguments.push(height.to_string());
         }

--- a/crates/ql_instances/src/instance/launch/launcher.rs
+++ b/crates/ql_instances/src/instance/launch/launcher.rs
@@ -121,6 +121,16 @@ impl GameLauncher {
             game_arguments.push("--disableSkinFix".to_owned());
         }
 
+        // Add custom resolution arguments if specified
+        if let Some(width) = self.config_json.window_width {
+            game_arguments.push("--width".to_owned());
+            game_arguments.push(width.to_string());
+        }
+        if let Some(height) = self.config_json.window_height {
+            game_arguments.push("--height".to_owned());
+            game_arguments.push(height.to_string());
+        }
+
         Ok(game_arguments)
     }
 

--- a/crates/ql_servers/src/create.rs
+++ b/crates/ql_servers/src/create.rs
@@ -120,6 +120,9 @@ async fn write_config(
         // This won't do anything on servers. Who wants to lose their *only way*
         // to control the server instantly after starting it?
         close_on_start: None,
+        // Resolution settings don't apply to servers
+        window_width: None,
+        window_height: None,
     };
     let server_config_path = server_dir.join("config.json");
     tokio::fs::write(

--- a/quantum_launcher/src/cli/command.rs
+++ b/quantum_launcher/src/cli/command.rs
@@ -170,6 +170,8 @@ pub fn launch_instance(
         username.clone(),
         None,
         account,
+        None,  // No global defaults in CLI mode
+        None,  // No global defaults in CLI mode
     ))?;
 
     if let (Some(stdout), Some(stderr)) = {

--- a/quantum_launcher/src/config.rs
+++ b/quantum_launcher/src/config.rs
@@ -90,6 +90,50 @@ pub struct LauncherConfig {
     /// Default: `true`
     // Since: v0.4.2
     pub antialiasing: Option<bool>,
+
+    /// The width of the window when the launcher was last closed.
+    /// Used to restore the window size between launches.
+    // Since: v0.4.3
+    pub window_width: Option<f32>,
+
+    /// The height of the window when the launcher was last closed.
+    /// Used to restore the window size between launches.
+    // Since: v0.4.3
+    pub window_height: Option<f32>,
+
+    /// **Global Default** - Custom window width for Minecraft instances.
+    ///
+    /// **Default: `None` (uses Minecraft's default)**
+    ///
+    /// When set, this will be used as the default window width for all new
+    /// instances and for instances that don't have their own width configured.
+    /// Individual instances can override this setting in their Edit Instance tab.
+    ///
+    /// This is useful for:
+    /// - Setting a consistent resolution across all instances
+    /// - Matching your monitor's resolution
+    /// - Setting up a preferred default window size
+    ///
+    /// Note: This only affects windowed mode, not fullscreen.
+    // Since: v0.4.4
+    pub default_minecraft_width: Option<u32>,
+
+    /// **Global Default** - Custom window height for Minecraft instances.
+    ///
+    /// **Default: `None` (uses Minecraft's default)**
+    ///
+    /// When set, this will be used as the default window height for all new
+    /// instances and for instances that don't have their own height configured.
+    /// Individual instances can override this setting in their Edit Instance tab.
+    ///
+    /// This is useful for:
+    /// - Setting a consistent resolution across all instances
+    /// - Matching your monitor's resolution
+    /// - Setting up a preferred default window size
+    ///
+    /// Note: This only affects windowed mode, not fullscreen.
+    // Since: v0.4.4
+    pub default_minecraft_height: Option<u32>,
 }
 
 impl Default for LauncherConfig {
@@ -106,6 +150,10 @@ impl Default for LauncherConfig {
             java_installs: Some(Vec::new()),
             antialiasing: Some(true),
             account_selected: None,
+            window_width: None,
+            window_height: None,
+            default_minecraft_width: None,
+            default_minecraft_height: None,
         }
     }
 }

--- a/quantum_launcher/src/menu_renderer/edit_instance.rs
+++ b/quantum_launcher/src/menu_renderer/edit_instance.rs
@@ -80,6 +80,27 @@ impl MenuEditInstance {
                         widget::checkbox("Close launcher after game opens", self.config.close_on_start.unwrap_or(false))
                             .on_toggle(|t| Message::EditInstance(EditInstanceMessage::CloseLauncherToggle(t))),
                     ].spacing(5)))
+                    .push_maybe((!selected_instance.is_server()).then_some(widget::column![
+                        "Custom window resolution:",
+                        widget::text("Leave blank to use Minecraft's default window size").size(12).style(ts),
+                        widget::row![
+                            widget::text("Width:").width(50),
+                            widget::text_input(
+                                "1920",
+                                &self.config.window_width.map_or(String::new(), |w| w.to_string())
+                            )
+                            .on_input(|n| Message::EditInstance(EditInstanceMessage::WindowWidthChanged(n)))
+                            .width(100),
+                            widget::text("Height:").width(50),
+                            widget::text_input(
+                                "1080",
+                                &self.config.window_height.map_or(String::new(), |h| h.to_string())
+                            )
+                            .on_input(|n| Message::EditInstance(EditInstanceMessage::WindowHeightChanged(n)))
+                            .width(100),
+                        ].spacing(10).align_y(iced::alignment::Vertical::Center),
+                        widget::text("Common resolutions: 1920x1080, 1366x768, 2560x1440, 3840x2160").size(12).style(ts),
+                    ].spacing(5)))
                     .push(
                         widget::column![
                             widget::checkbox("DEBUG: Enable log system (recommended)", self.config.enable_logger.unwrap_or(true))

--- a/quantum_launcher/src/menu_renderer/edit_instance.rs
+++ b/quantum_launcher/src/menu_renderer/edit_instance.rs
@@ -91,7 +91,7 @@ impl MenuEditInstance {
                             )
                             .on_input(|n| Message::EditInstance(EditInstanceMessage::WindowWidthChanged(n)))
                             .width(100),
-                            widget::text("Height:").width(50),
+                            widget::text("Height").width(50),
                             widget::text_input(
                                 "1080",
                                 &self.config.window_height.map_or(String::new(), |h| h.to_string())

--- a/quantum_launcher/src/menu_renderer/settings.rs
+++ b/quantum_launcher/src/menu_renderer/settings.rs
@@ -170,6 +170,31 @@ impl LauncherSettingsTab {
                 .padding(10),
                 widget::horizontal_rule(1),
                 widget::column![
+                    widget::text("Default Minecraft Resolution").size(16),
+                    widget::text("Set default window size for all new instances. Individual instances can override these settings.").size(12),
+                    widget::column![
+                        widget::text("Width:"),
+                        widget::text_input(
+                            "e.g. 1920 (leave empty for Minecraft default)",
+                            &config.default_minecraft_width.map(|w| w.to_string()).unwrap_or_default()
+                        )
+                        .on_input(|input| Message::LauncherSettings(LauncherSettingsMessage::DefaultMinecraftWidthChanged(input)))
+                        .width(Length::Fixed(200.0)),
+                    ].spacing(5),
+                    widget::column![
+                        widget::text("Height"),
+                        widget::text_input(
+                            "e.g. 1080 (leave empty for Minecraft default)",
+                            &config.default_minecraft_height.map(|h| h.to_string()).unwrap_or_default()
+                        )
+                        .on_input(|input| Message::LauncherSettings(LauncherSettingsMessage::DefaultMinecraftHeightChanged(input)))
+                        .width(Length::Fixed(200.0)),
+                    ].spacing(5),
+                ]
+                .padding(10)
+                .spacing(10),
+                widget::horizontal_rule(1),
+                widget::column![
                     button_with_icon(icon_manager::delete(), "Clear Java installs", 16).on_press(
                         Message::LauncherSettings(LauncherSettingsMessage::ClearJavaInstalls)
                     ),

--- a/quantum_launcher/src/message_handler/mod.rs
+++ b/quantum_launcher/src/message_handler/mod.rs
@@ -54,9 +54,11 @@ impl Launcher {
         }
 
         let instance_name = selected_instance.to_owned();
+        let global_width = self.config.default_minecraft_width;
+        let global_height = self.config.default_minecraft_height;
         Task::perform(
             async move {
-                ql_instances::launch(instance_name, username, Some(sender), account_data)
+                ql_instances::launch(instance_name, username, Some(sender), account_data, global_width, global_height)
                     .await
                     .strerr()
             },

--- a/quantum_launcher/src/message_update/edit_instance.rs
+++ b/quantum_launcher/src/message_update/edit_instance.rs
@@ -91,6 +91,32 @@ impl Launcher {
             }
             EditInstanceMessage::RenameApply => return self.rename_instance(),
             EditInstanceMessage::ConfigSaved(res) => res?,
+            EditInstanceMessage::WindowWidthChanged(width_str) => {
+                if let State::Launch(MenuLaunch {
+                    edit_instance: Some(menu),
+                    ..
+                }) = &mut self.state
+                {
+                    if width_str.is_empty() {
+                        menu.config.window_width = None;
+                    } else if let Ok(width) = width_str.parse::<u32>() {
+                        menu.config.window_width = Some(width);
+                    }
+                }
+            }
+            EditInstanceMessage::WindowHeightChanged(height_str) => {
+                if let State::Launch(MenuLaunch {
+                    edit_instance: Some(menu),
+                    ..
+                }) = &mut self.state
+                {
+                    if height_str.is_empty() {
+                        menu.config.window_height = None;
+                    } else if let Ok(height) = height_str.parse::<u32>() {
+                        menu.config.window_height = Some(height);
+                    }
+                }
+            }
         }
         Ok(Task::none())
     }

--- a/quantum_launcher/src/message_update/mod.rs
+++ b/quantum_launcher/src/message_update/mod.rs
@@ -498,6 +498,20 @@ impl Launcher {
             LauncherSettingsMessage::ToggleAntialiasing(t) => {
                 self.config.antialiasing = Some(t);
             }
+            LauncherSettingsMessage::DefaultMinecraftWidthChanged(input) => {
+                self.config.default_minecraft_width = if input.trim().is_empty() {
+                    None
+                } else {
+                    input.trim().parse::<u32>().ok()
+                };
+            }
+            LauncherSettingsMessage::DefaultMinecraftHeightChanged(input) => {
+                self.config.default_minecraft_height = if input.trim().is_empty() {
+                    None
+                } else {
+                    input.trim().parse::<u32>().ok()
+                };
+            }
         }
         Task::none()
     }

--- a/quantum_launcher/src/state/message.rs
+++ b/quantum_launcher/src/state/message.rs
@@ -216,6 +216,8 @@ pub enum LauncherSettingsMessage {
     ClearJavaInstallsConfirm,
     ChangeTab(LauncherSettingsTab),
     ToggleAntialiasing(bool),
+    DefaultMinecraftWidthChanged(String),
+    DefaultMinecraftHeightChanged(String),
 }
 
 #[derive(Debug, Clone)]

--- a/quantum_launcher/src/state/message.rs
+++ b/quantum_launcher/src/state/message.rs
@@ -70,6 +70,8 @@ pub enum EditInstanceMessage {
     GameArgShiftDown(usize),
     RenameEdit(String),
     RenameApply,
+    WindowWidthChanged(String),
+    WindowHeightChanged(String),
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This PR implements the feature requested in issue #58 to allow manually setting the game's window size.  

- Adds an optional setting to specify window size  
- Supports global or per-instance configuration  
- Inspired by similar features in Prism and ATLauncher  
- Improves user convenience by letting players control their game window dimensions  

Closes #58
<img width="734" height="523" alt="1" src="https://github.com/user-attachments/assets/83d8d604-c640-4d36-8a58-41306d595043" />

<img width="734" height="523" alt="2" src="https://github.com/user-attachments/assets/895a539c-bc24-443b-bb61-123a576b6439" />
