### PR TITLE
Replace Deprecated zip-extract with zip Crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3490,7 +3490,6 @@ dependencies = [
  "tokio-util",
  "walkdir",
  "zip",
- "zip-extract",
 ]
 
 [[package]]
@@ -3512,7 +3511,7 @@ dependencies = [
  "thiserror 2.0.14",
  "tokio",
  "urlencoding",
- "zip-extract",
+ "zip",
 ]
 
 [[package]]
@@ -3528,7 +3527,7 @@ dependencies = [
  "tar",
  "thiserror 2.0.14",
  "tokio",
- "zip-extract",
+ "zip",
 ]
 
 [[package]]
@@ -3548,7 +3547,6 @@ dependencies = [
  "thiserror 2.0.14",
  "tokio",
  "zip",
- "zip-extract",
 ]
 
 [[package]]
@@ -3567,7 +3565,6 @@ dependencies = [
  "thiserror 2.0.14",
  "tokio",
  "zip",
- "zip-extract",
 ]
 
 [[package]]
@@ -3589,7 +3586,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.14",
  "tokio",
- "zip-extract",
+ "zip",
 ]
 
 [[package]]
@@ -6451,17 +6448,6 @@ dependencies = [
  "indexmap",
  "memchr",
  "zopfli",
-]
-
-[[package]]
-name = "zip-extract"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa5b9958fd0b5b685af54f2c3fa21fca05fe295ebaf3e77b6d24d96c4174037"
-dependencies = [
- "log",
- "thiserror 2.0.14",
- "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,6 @@ rfd = { version = "0.15", default-features = false, features = [
     "tokio",
 ] }
 
-zip-extract = { version = "0.4", default-features = false, features = [
-    "deflate",
-] }
 zip = { version = "4", default-features = false, features = ["deflate"] }
 walkdir = "2.3"
 image = { version = "0.24", default-features = false, features = [

--- a/crates/ql_core/Cargo.toml
+++ b/crates/ql_core/Cargo.toml
@@ -12,9 +12,8 @@ dirs = "6"
 futures = { workspace = true }
 colored = { workspace = true }
 
-zip-extract = { workspace = true }
 zip = { workspace = true }
-walkdir = "2"
+walkdir = { workspace = true }
 regex = "1"
 
 tokio = { workspace = true }

--- a/crates/ql_instances/Cargo.toml
+++ b/crates/ql_instances/Cargo.toml
@@ -17,7 +17,7 @@ ql_reqwest = { path = "../ql_reqwest" }
 
 chrono = { workspace = true }
 semver = "1"
-zip-extract = { workspace = true }
+zip = { workspace = true }
 
 tokio = { workspace = true }
 

--- a/crates/ql_instances/src/download/downloader.rs
+++ b/crates/ql_instances/src/download/downloader.rs
@@ -34,7 +34,7 @@ pub enum DownloadError {
     #[error("{DOWNLOAD_ERR_PREFIX}in assets JSON, field not found: \"{0}\"")]
     AssetsJsonFieldNotFound(String),
     #[error("{DOWNLOAD_ERR_PREFIX}could not extract native libraries:\n{0}")]
-    NativesExtractError(#[from] zip_extract::ZipExtractError),
+    NativesExtractError(#[from] zip::result::ZipError),
     #[error("{DOWNLOAD_ERR_PREFIX}tried to remove natives outside folder. POTENTIAL SECURITY RISK AVOIDED")]
     NativesOutsideDirRemove,
 }

--- a/crates/ql_instances/src/launcher_update_detector.rs
+++ b/crates/ql_instances/src/launcher_update_detector.rs
@@ -2,7 +2,6 @@ use std::{
     ffi::OsStr,
     process::Command,
     sync::{mpsc::Sender, Arc},
-    path::Path,
 };
 
 use ql_core::{
@@ -11,46 +10,8 @@ use ql_core::{
 };
 use serde::Deserialize;
 use thiserror::Error;
-use zip::ZipArchive;
 
 use crate::LAUNCHER_VERSION;
-
-/// Extract a ZIP archive to a directory using the new zip crate API
-fn extract_zip_archive<R: std::io::Read + std::io::Seek>(
-    reader: R, 
-    extract_to: &Path
-) -> Result<(), zip::result::ZipError> {
-    let mut archive = ZipArchive::new(reader)?;
-    
-    for i in 0..archive.len() {
-        let mut file = archive.by_index(i)?;
-        let outpath = match file.enclosed_name() {
-            Some(path) => extract_to.join(path),
-            None => continue,
-        };
-
-        if file.is_dir() {
-            std::fs::create_dir_all(&outpath)?;
-        } else {
-            if let Some(p) = outpath.parent() {
-                if !p.exists() {
-                    std::fs::create_dir_all(p)?;
-                }
-            }
-            let mut outfile = std::fs::File::create(&outpath)?;
-            std::io::copy(&mut file, &mut outfile)?;
-        }
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            if let Some(mode) = file.unix_mode() {
-                std::fs::set_permissions(&outpath, std::fs::Permissions::from_mode(mode))?;
-            }
-        }
-    }
-    Ok(())
-}
 
 #[derive(Debug, Clone)]
 pub enum UpdateCheckInfo {
@@ -231,7 +192,7 @@ pub async fn install_launcher_update(
         message: Some("Extracting new launcher".to_owned()),
         has_finished: false,
     });
-    extract_zip_archive(std::io::Cursor::new(download_zip), exe_location)?;
+    file_utils::extract_zip_archive(std::io::Cursor::new(download_zip), exe_location, true)?;
 
     // Should I, though?
     let rm_path = exe_location.join("README.md");

--- a/crates/ql_java_handler/Cargo.toml
+++ b/crates/ql_java_handler/Cargo.toml
@@ -15,5 +15,5 @@ colored = { workspace = true }
 # Avengers assemble
 flate2 = "1"
 tar = "0.4"
-zip-extract = { workspace = true }
+zip = { workspace = true }
 lzma-rs = "0.3"

--- a/crates/ql_java_handler/src/alternate_java.rs
+++ b/crates/ql_java_handler/src/alternate_java.rs
@@ -52,6 +52,43 @@ use ql_core::{file_utils, GenericProgress};
 
 use crate::{extract_tar_gz, send_progress, JavaInstallError, JavaVersion};
 
+/// Extract a ZIP archive to a directory using the new zip crate API
+fn extract_zip_archive<R: std::io::Read + std::io::Seek>(
+    reader: R, 
+    extract_to: &Path
+) -> Result<(), zip::result::ZipError> {
+    let mut archive = zip::ZipArchive::new(reader)?;
+    
+    for i in 0..archive.len() {
+        let mut file = archive.by_index(i)?;
+        let outpath = match file.enclosed_name() {
+            Some(path) => extract_to.join(path),
+            None => continue,
+        };
+
+        if file.is_dir() {
+            std::fs::create_dir_all(&outpath)?;
+        } else {
+            if let Some(p) = outpath.parent() {
+                if !p.exists() {
+                    std::fs::create_dir_all(p)?;
+                }
+            }
+            let mut outfile = std::fs::File::create(&outpath)?;
+            std::io::copy(&mut file, &mut outfile)?;
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Some(mode) = file.unix_mode() {
+                std::fs::set_permissions(&outpath, std::fs::Permissions::from_mode(mode))?;
+            }
+        }
+    }
+    Ok(())
+}
+
 pub(crate) async fn install(
     version: JavaVersion,
     java_install_progress_sender: Option<&Sender<GenericProgress>>,
@@ -85,7 +122,7 @@ pub(crate) async fn install(
     if url.ends_with("tar.gz") {
         extract_tar_gz(&file_bytes, install_dir).map_err(JavaInstallError::TarGzExtract)?;
     } else if url.ends_with("zip") {
-        zip_extract::extract(Cursor::new(&file_bytes), install_dir, true)?;
+        extract_zip_archive(Cursor::new(&file_bytes), install_dir)?;
     } else {
         return Err(JavaInstallError::UnknownExtension(url.to_owned()));
     }

--- a/crates/ql_java_handler/src/lib.rs
+++ b/crates/ql_java_handler/src/lib.rs
@@ -20,7 +20,6 @@ pub mod alternate_java;
 mod json;
 
 pub use json::list::JavaVersion;
-use zip_extract::ZipExtractError;
 
 #[cfg(target_os = "windows")]
 pub const JAVA: &str = "javaw";
@@ -310,7 +309,7 @@ pub enum JavaInstallError {
     UnsupportedPlatform,
 
     #[error("{JAVA_INSTALL_ERR_PREFIX}zip extract error:\n{0}")]
-    ZipExtract(#[from] ZipExtractError),
+    ZipExtract(#[from] zip::result::ZipError),
     #[error("{JAVA_INSTALL_ERR_PREFIX}couldn't extract java tar.gz:\n{0}")]
     TarGzExtract(std::io::Error),
     #[error("{JAVA_INSTALL_ERR_PREFIX}unknown extension for java: {0}\n\nTHIS IS A BUG, PLEASE REPORT ON DISCORD")]

--- a/crates/ql_mod_manager/Cargo.toml
+++ b/crates/ql_mod_manager/Cargo.toml
@@ -13,7 +13,6 @@ ql_reqwest = { path = "../ql_reqwest" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
-zip-extract = { workspace = true }
 zip = { workspace = true }
 
 tokio = { workspace = true }

--- a/crates/ql_mod_manager/src/loaders/forge/error.rs
+++ b/crates/ql_mod_manager/src/loaders/forge/error.rs
@@ -3,7 +3,6 @@ use std::{num::ParseIntError, path::PathBuf, string::FromUtf8Error};
 use ql_core::{impl_3_errs_jri, DownloadFileError, IoError, JsonError, RequestError};
 use ql_java_handler::JavaInstallError;
 use thiserror::Error;
-use zip_extract::ZipExtractError;
 
 const FORGE_INSTALL_ERR_PREFIX: &str = "while installing Forge:\n";
 
@@ -40,8 +39,6 @@ pub enum ForgeInstallError {
     #[error("NeoForge only supports Minecraft 1.20.2 and above, your version is outdated")]
     NeoforgeOutdatedMinecraft,
 
-    #[error("{FORGE_INSTALL_ERR_PREFIX}zip extract: {0}")]
-    ZipExtract(#[from] ZipExtractError),
     #[error("{FORGE_INSTALL_ERR_PREFIX}zip: {0}")]
     Zip(#[from] zip::result::ZipError),
     #[error("{FORGE_INSTALL_ERR_PREFIX}couldn't read file {1} from zip:\n{0}")]

--- a/crates/ql_mod_manager/src/store/error.rs
+++ b/crates/ql_mod_manager/src/store/error.rs
@@ -2,7 +2,6 @@ use std::num::ParseIntError;
 
 use ql_core::{impl_3_errs_jri, IoError, JsonError, RequestError};
 use thiserror::Error;
-use zip_extract::ZipError;
 
 use super::modpack::PackError;
 
@@ -23,7 +22,7 @@ pub enum ModError {
     #[error("{MOD_ERR_PREFIX}couldn't add entry {1} to zip: {0}")]
     ZipIoError(std::io::Error, String),
     #[error("{MOD_ERR_PREFIX}zip error:\n{0}")]
-    Zip(#[from] ZipError),
+    Zip(#[from] zip::result::ZipError),
     #[error("{MOD_ERR_PREFIX}no \"minecraft\" game entry found in curseforge API\n\nThis is a bug, please report in discord!")]
     NoMinecraftInCurseForge,
     #[error("curseforge is blocking you from downloading the mod {0}\nGo to the official website at:\nhttps://www.curseforge.com/minecraft/mc-mods/{1}\nand download from there")]

--- a/crates/ql_packager/Cargo.toml
+++ b/crates/ql_packager/Cargo.toml
@@ -18,6 +18,5 @@ serde_json = { workspace = true }
 
 tempfile = { workspace = true }
 
-zip-extract = { workspace = true }
 zip = { workspace = true }
 rust-ini = { version = "0.21", features = ["inline-comment"] }

--- a/crates/ql_packager/src/import.rs
+++ b/crates/ql_packager/src/import.rs
@@ -12,48 +12,10 @@ use std::{
     },
 };
 use tokio::fs;
-use zip::ZipArchive;
 
 use crate::InstanceInfo;
 
 use super::InstancePackageError;
-
-/// Extract a ZIP archive to a directory using the new zip crate API
-fn extract_zip_archive<R: std::io::Read + std::io::Seek>(
-    reader: R, 
-    extract_to: &Path
-) -> Result<(), zip::result::ZipError> {
-    let mut archive = ZipArchive::new(reader)?;
-    
-    for i in 0..archive.len() {
-        let mut file = archive.by_index(i)?;
-        let outpath = match file.enclosed_name() {
-            Some(path) => extract_to.join(path),
-            None => continue,
-        };
-
-        if file.is_dir() {
-            std::fs::create_dir_all(&outpath)?;
-        } else {
-            if let Some(p) = outpath.parent() {
-                if !p.exists() {
-                    std::fs::create_dir_all(p)?;
-                }
-            }
-            let mut outfile = std::fs::File::create(&outpath)?;
-            std::io::copy(&mut file, &mut outfile)?;
-        }
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            if let Some(mode) = file.unix_mode() {
-                std::fs::set_permissions(&outpath, std::fs::Permissions::from_mode(mode))?;
-            }
-        }
-    }
-    Ok(())
-}
 
 pub const OUT_OF: usize = 4;
 
@@ -99,7 +61,7 @@ pub async fn import_instance(
             has_finished: false,
         });
     }
-    extract_zip_archive(std::io::BufReader::new(zip_file), temp_dir)?;
+    file_utils::extract_zip_archive(std::io::BufReader::new(zip_file), temp_dir, true)?;
 
     let try_ql = temp_dir.join("quantum-config.json");
     let try_mmc = temp_dir.join("mmc-pack.json");

--- a/crates/ql_packager/src/import.rs
+++ b/crates/ql_packager/src/import.rs
@@ -12,11 +12,48 @@ use std::{
     },
 };
 use tokio::fs;
-use zip_extract::extract;
+use zip::ZipArchive;
 
 use crate::InstanceInfo;
 
 use super::InstancePackageError;
+
+/// Extract a ZIP archive to a directory using the new zip crate API
+fn extract_zip_archive<R: std::io::Read + std::io::Seek>(
+    reader: R, 
+    extract_to: &Path
+) -> Result<(), zip::result::ZipError> {
+    let mut archive = ZipArchive::new(reader)?;
+    
+    for i in 0..archive.len() {
+        let mut file = archive.by_index(i)?;
+        let outpath = match file.enclosed_name() {
+            Some(path) => extract_to.join(path),
+            None => continue,
+        };
+
+        if file.is_dir() {
+            std::fs::create_dir_all(&outpath)?;
+        } else {
+            if let Some(p) = outpath.parent() {
+                if !p.exists() {
+                    std::fs::create_dir_all(p)?;
+                }
+            }
+            let mut outfile = std::fs::File::create(&outpath)?;
+            std::io::copy(&mut file, &mut outfile)?;
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Some(mode) = file.unix_mode() {
+                std::fs::set_permissions(&outpath, std::fs::Permissions::from_mode(mode))?;
+            }
+        }
+    }
+    Ok(())
+}
 
 pub const OUT_OF: usize = 4;
 
@@ -62,7 +99,7 @@ pub async fn import_instance(
             has_finished: false,
         });
     }
-    extract(zip_file, temp_dir, true)?;
+    extract_zip_archive(std::io::BufReader::new(zip_file), temp_dir)?;
 
     let try_ql = temp_dir.join("quantum-config.json");
     let try_mmc = temp_dir.join("mmc-pack.json");

--- a/crates/ql_packager/src/lib.rs
+++ b/crates/ql_packager/src/lib.rs
@@ -5,7 +5,6 @@ use ql_mod_manager::loaders::{fabric::FabricInstallError, forge::ForgeInstallErr
 use ql_servers::ServerError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use zip_extract::ZipExtractError;
 
 use ql_instances::DownloadError;
 
@@ -41,8 +40,6 @@ pub enum InstancePackageError {
     #[error("{PKG_ERR_PREFIX}{0}")]
     Fabric(#[from] FabricInstallError),
 
-    #[error("{PKG_ERR_PREFIX}while extracting zip:\n{0}")]
-    ZipExtract(#[from] ZipExtractError),
     #[error("{PKG_ERR_PREFIX}while dealing with zip:\n{0}")]
     Zip(#[from] zip::result::ZipError),
 

--- a/crates/ql_servers/Cargo.toml
+++ b/crates/ql_servers/Cargo.toml
@@ -11,6 +11,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 colored = { workspace = true }
-zip-extract = { workspace = true }
+zip = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true }

--- a/crates/ql_servers/src/create.rs
+++ b/crates/ql_servers/src/create.rs
@@ -1,12 +1,50 @@
-use std::sync::mpsc::Sender;
+use std::{sync::mpsc::Sender, path::Path};
 
 use ql_core::{
     file_utils, info,
     json::{InstanceConfigJson, Manifest, VersionDetails},
     pt, GenericProgress, IntoIoError, IntoJsonError, IntoStringError, ListEntry, LAUNCHER_DIR,
 };
+use zip::ZipArchive;
 
 use crate::ServerError;
+
+/// Extract a ZIP archive to a directory using the new zip crate API
+fn extract_zip_archive<R: std::io::Read + std::io::Seek>(
+    reader: R, 
+    extract_to: &Path
+) -> Result<(), zip::result::ZipError> {
+    let mut archive = ZipArchive::new(reader)?;
+    
+    for i in 0..archive.len() {
+        let mut file = archive.by_index(i)?;
+        let outpath = match file.enclosed_name() {
+            Some(path) => extract_to.join(path),
+            None => continue,
+        };
+
+        if file.is_dir() {
+            std::fs::create_dir_all(&outpath)?;
+        } else {
+            if let Some(p) = outpath.parent() {
+                if !p.exists() {
+                    std::fs::create_dir_all(p)?;
+                }
+            }
+            let mut outfile = std::fs::File::create(&outpath)?;
+            std::io::copy(&mut file, &mut outfile)?;
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Some(mode) = file.unix_mode() {
+                std::fs::set_permissions(&outpath, std::fs::Permissions::from_mode(mode))?;
+            }
+        }
+    }
+    Ok(())
+}
 
 /// Creates a minecraft server with the given name and version.
 ///
@@ -72,7 +110,7 @@ pub async fn create_server(
         is_classic_server = true;
 
         let archive = file_utils::download_file_to_bytes(&server.url, true).await?;
-        zip_extract::extract(std::io::Cursor::new(archive), &server_dir, true)?;
+        extract_zip_archive(std::io::Cursor::new(archive), &server_dir)?;
 
         let old_path = server_dir.join("minecraft-server.jar");
         tokio::fs::rename(&old_path, &server_jar_path)

--- a/crates/ql_servers/src/lib.rs
+++ b/crates/ql_servers/src/lib.rs
@@ -25,7 +25,6 @@ pub use server_properties::ServerProperties;
 // pub use ssh::run_tunnel;
 
 use thiserror::Error;
-use zip_extract::ZipExtractError;
 
 const SERVER_ERR_PREFIX: &str = "while managing server:\n";
 
@@ -48,7 +47,7 @@ pub enum ServerError {
     #[error("A server with that name already exists!")]
     ServerAlreadyExists,
     #[error("{SERVER_ERR_PREFIX}zip extract error:\n{0}")]
-    ZipExtract(#[from] ZipExtractError),
+    ZipExtract(#[from] zip::result::ZipError),
     #[error("{SERVER_ERR_PREFIX}couldn't find forge shim file")]
     NoForgeShimFound,
     #[error("{SERVER_ERR_PREFIX}couldn't convert PathBuf to str: {0:?}")]


### PR DESCRIPTION
This PR replaces the deprecated `zip-extract` crate with the modern `zip` crate (v4.x). This removes deprecation warnings.