### PR TITLE
File opening bug

### DIFF
--- a/crates/ql_core/src/lib.rs
+++ b/crates/ql_core/src/lib.rs
@@ -385,7 +385,6 @@ pub fn open_file_explorer<S: AsRef<OsStr>>(path: S) {
     let result = if cfg!(target_os = "linux") || cfg!(target_os = "freebsd") {
         Command::new("xdg-open").arg(path).spawn()
     } else if cfg!(target_os = "windows") {
-        // Use 'cmd /c start /b' to respect user's default file manager without showing terminal
         #[cfg(target_os = "windows")]
         {
             use std::os::windows::process::CommandExt;

--- a/crates/ql_core/src/lib.rs
+++ b/crates/ql_core/src/lib.rs
@@ -369,45 +369,41 @@ pub enum SelectedMod {
 /// If you input a path (for example, `C:\Users\Mrmayman\Documents\`)
 /// this will open it in the file explorer using the system's default file manager.
 ///
-/// On Windows, this respects the user's default file manager and runs silently
-/// without showing a terminal window.
+/// # Platform details
+/// - Linux, BSDs: `xdg-open <PATH>`
+/// - macOS: `open <PATH>`
+/// - Windows: `cmd /c start /b <PATH>`
 ///
-/// # Panics
-/// Only supported on windows, macOS and linux,
-/// other platforms will **panic**.
+/// Unsupported platforms will log an error and not open anything.
 #[allow(clippy::zombie_processes)]
 pub fn open_file_explorer<S: AsRef<OsStr>>(path: S) {
     use std::process::Command;
 
     let path = path.as_ref();
     info!("Opening link: {}", path.to_string_lossy());
-    
-    let result = if cfg!(target_os = "linux") || cfg!(target_os = "freebsd") {
-        Command::new("xdg-open").arg(path).spawn()
-    } else if cfg!(target_os = "windows") {
-        #[cfg(target_os = "windows")]
-        {
-            use std::os::windows::process::CommandExt;
-            const CREATE_NO_WINDOW: u32 = 0x08000000;
-            Command::new("cmd")
-                .args(["/c", "start", "/b", ""])
-                .arg(path)
-                .creation_flags(CREATE_NO_WINDOW)
-                .spawn()
-        }
-        #[cfg(not(target_os = "windows"))]
-        {
-            // Fallback for non-Windows builds
-            Command::new("cmd").args(["/c", "start", "/b", ""]).arg(path).spawn()
-        }
-    } else if cfg!(target_os = "macos") {
-        Command::new("open").arg(path).spawn()
-    } else {
-        panic!("Opening file explorer not supported on this platform.")
+
+    #[allow(unused)]
+    let result: std::io::Result<()> = Err(std::io::Error::other("Unsupported Platform!"));
+
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
+    let result = Command::new("xdg-open").arg(path).spawn();
+    #[cfg(target_os = "macos")]
+    let result = Command::new("open").arg(path).spawn();
+    #[cfg(target_os = "windows")]
+    let result = {
+        // To not flash a terminal window
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+        // Respects the user's default file manager
+        Command::new("cmd")
+            .args(["/c", "start", "/b", ""])
+            .arg(path)
+            .creation_flags(CREATE_NO_WINDOW)
+            .spawn()
     };
-    
-    if let Err(err) = result
-    {
+
+    if let Err(err) = result {
         err!("Could not open link: {err}");
     }
 }

--- a/crates/ql_core/src/lib.rs
+++ b/crates/ql_core/src/lib.rs
@@ -367,7 +367,10 @@ pub enum SelectedMod {
 /// this will open the link with your default browser.
 ///
 /// If you input a path (for example, `C:\Users\Mrmayman\Documents\`)
-/// this will open it in the file explorer.
+/// this will open it in the file explorer using the system's default file manager.
+///
+/// On Windows, this respects the user's default file manager and runs silently
+/// without showing a terminal window.
 ///
 /// # Panics
 /// Only supported on windows, macOS and linux,
@@ -378,19 +381,33 @@ pub fn open_file_explorer<S: AsRef<OsStr>>(path: S) {
 
     let path = path.as_ref();
     info!("Opening link: {}", path.to_string_lossy());
-    if let Err(err) = Command::new(
-        if cfg!(target_os = "linux") || cfg!(target_os = "freebsd") {
-            "xdg-open"
-        } else if cfg!(target_os = "windows") {
-            "explorer"
-        } else if cfg!(target_os = "macos") {
-            "open"
-        } else {
-            panic!("Opening file explorer not supported on this platform.")
-        },
-    )
-    .arg(path)
-    .spawn()
+    
+    let result = if cfg!(target_os = "linux") || cfg!(target_os = "freebsd") {
+        Command::new("xdg-open").arg(path).spawn()
+    } else if cfg!(target_os = "windows") {
+        // Use 'cmd /c start /b' to respect user's default file manager without showing terminal
+        #[cfg(target_os = "windows")]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            Command::new("cmd")
+                .args(["/c", "start", "/b", ""])
+                .arg(path)
+                .creation_flags(CREATE_NO_WINDOW)
+                .spawn()
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            // Fallback for non-Windows builds
+            Command::new("cmd").args(["/c", "start", "/b", ""]).arg(path).spawn()
+        }
+    } else if cfg!(target_os = "macos") {
+        Command::new("open").arg(path).spawn()
+    } else {
+        panic!("Opening file explorer not supported on this platform.")
+    };
+    
+    if let Err(err) = result
     {
         err!("Could not open link: {err}");
     }


### PR DESCRIPTION
Closes #66

Previously,  Launcher always opened instance folders using **Windows File Explorer**, ignoring any alternative file explorers the user might have set.  

This PR updates the launcher to use the **system’s default file explorer** when opening instance folders. 