### PR TITLE
Fixed "Open Website" button on the "A new launcher update has been fo…

### DIFF
--- a/quantum_launcher/src/menu_renderer/mod.rs
+++ b/quantum_launcher/src/menu_renderer/mod.rs
@@ -254,7 +254,7 @@ impl MenuLauncherUpdate {
                         }
                     ),
                     button_with_icon(icon_manager::globe(), "Open Website", 16)
-                        .on_press(Message::CoreOpenLink("https://mrmayman.github.com/quantumlauncher".to_owned())),
+                        .on_press(Message::CoreOpenLink("https://mrmayman.github.io/quantumlauncher".to_owned())),
                 ).push_maybe(cfg!(target_os = "linux").then_some(
                     widget::column!(
                         // WARN: Package manager


### PR DESCRIPTION
Fixed "Open Website" button on the "A new launcher update has been found! Do you want to download it?" screen, pointing to "https://mrmayman.github.COM/quantumlauncher" instead of "https://mrmayman.github.IO/quantumlauncher"