### PR TITLE
 Add Custom JAR Support for Minecraft Instances

### DIFF
--- a/crates/ql_core/src/jarmod/mod.rs
+++ b/crates/ql_core/src/jarmod/mod.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf, StripPrefixError};
 use crate::{
     file_utils::{zip_directory_to_bytes, extract_zip_archive},
     get_jar_path,
-    json::{JsonOptifine, VersionDetails},
+    json::{InstanceConfigJson, JsonOptifine, VersionDetails},
     pt, InstanceSelection, IntoIoError, IoError, JsonError, JsonFileError,
 };
 use thiserror::Error;
@@ -139,10 +139,16 @@ async fn get_original_jar(
 ) -> Result<PathBuf, JarModError> {
     let json = VersionDetails::load(instance).await?;
     let optifine = JsonOptifine::read(instance.get_name()).await.ok();
+    let config = InstanceConfigJson::read(instance).await.ok();
+    let custom_jar_path = config
+        .and_then(|c| c.custom_jar)
+        .map(|cj| cj.jar_path);
+    
     Ok(get_jar_path(
         &json,
         instance_dir,
         optifine.as_ref().map(|n| n.1.as_path()),
+        custom_jar_path.as_deref(),
     ))
 }
 

--- a/crates/ql_core/src/json/instance_config.rs
+++ b/crates/ql_core/src/json/instance_config.rs
@@ -4,6 +4,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::{InstanceSelection, IntoIoError, IntoJsonError, JsonFileError};
 
+/// Configuration for using a custom Minecraft JAR file
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct CustomJarConfig {
+    /// Path to the custom JAR file
+    pub jar_path: String,
+}
+
 /// Defines how instance Java arguments should interact with global Java arguments
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum JavaArgsMode {
@@ -170,6 +177,20 @@ pub struct InstanceConfigJson {
     /// - `Override`: Instance args completely replace global args (ignore global when instance has args)
     /// - `Combine`: Global args are prepended to instance args (both are used together)
     pub java_args_mode: Option<JavaArgsMode>,
+
+    /// **Client Only**
+    ///
+    /// Custom jar configuration for using alternative client jars.
+    /// When set, the launcher will use the specified custom jar instead of the default
+    /// Minecraft jar, but will use assets from the instance's configured version.
+    ///
+    /// This is useful for:
+    /// - Modified client jars (e.g., Cypress, Omniarchive special versions)
+    /// - Custom modded jars not available through official channels
+    /// - Client jars from external sources
+    ///
+    /// **Default: `None`** (use official Minecraft jar)
+    pub custom_jar: Option<CustomJarConfig>,
 }
 
 impl InstanceConfigJson {

--- a/crates/ql_core/src/lib.rs
+++ b/crates/ql_core/src/lib.rs
@@ -465,6 +465,7 @@ pub fn get_jar_path(
     version_json: &VersionDetails,
     instance_dir: &Path,
     optifine_jar: Option<&Path>,
+    custom_jar: Option<&str>,
 ) -> PathBuf {
     fn get_path_from_id(instance_dir: &Path, id: &str) -> PathBuf {
         instance_dir
@@ -473,6 +474,12 @@ pub fn get_jar_path(
             .join(format!("{id}.jar"))
     }
 
+    // If custom jar is specified, use it first
+    if let Some(custom_jar_path) = custom_jar {
+        return PathBuf::from(custom_jar_path);
+    }
+
+    // Otherwise fall back to existing logic
     optifine_jar.map_or_else(
         || {
             let id = version_json.get_id();

--- a/crates/ql_instances/src/download/downloader.rs
+++ b/crates/ql_instances/src/download/downloader.rs
@@ -323,6 +323,8 @@ impl GameDownloader {
             omniarchive: None,
             global_settings: None,
             java_args_mode: None,
+            // Custom JAR is not set by default
+            custom_jar: None,
         };
         let config_json = serde_json::to_string(&config_json).json_to()?;
 

--- a/crates/ql_servers/src/create.rs
+++ b/crates/ql_servers/src/create.rs
@@ -122,6 +122,8 @@ async fn write_config(
         close_on_start: None,
         global_settings: None,
         java_args_mode: None,
+        // Custom JAR is not supported for servers
+        custom_jar: None,
     };
     let server_config_path = server_dir.join("config.json");
     tokio::fs::write(

--- a/quantum_launcher/src/menu_renderer/edit_instance.rs
+++ b/quantum_launcher/src/menu_renderer/edit_instance.rs
@@ -46,6 +46,9 @@ impl MenuEditInstance {
                     self.item_java_override()
                 ).style(|n: &LauncherTheme| n.style_container_sharp_box(0.0, Color::Dark)),
                 widget::container(
+                    self.item_custom_jar()
+                ).style(|n: &LauncherTheme| n.style_container_sharp_box(0.0, Color::ExtraDark)),
+                widget::container(
                     self.item_mem_alloc(),
                 ).style(|n: &LauncherTheme| n.style_container_sharp_box(0.0, Color::ExtraDark)),
                 widget::container(
@@ -191,6 +194,46 @@ impl MenuEditInstance {
         ]
         .padding(10)
         .spacing(10)
+    }
+
+    fn item_custom_jar(&self) -> widget::Column<'_, Message, LauncherTheme> {
+        let ts = |n: &LauncherTheme| n.style_text(Color::SecondLight);
+        let is_enabled = self.config.custom_jar.is_some();
+
+        let mut column = widget::column![
+            widget::checkbox(
+                "Use custom Minecraft JAR",
+                is_enabled
+            ).on_toggle(|t| Message::EditInstance(EditInstanceMessage::CustomJarToggle(t))),
+            widget::text(
+                "Use a custom Minecraft client JAR instead of the official one.\nUseful for modified clients, archived versions, or custom modded JARs.\nAssets will be used from this instance's selected version."
+            )
+            .size(12)
+            .style(ts),
+        ];
+
+        if is_enabled {
+            column = column.push(widget::column![
+                widget::text("JAR file path:").size(14),
+                widget::row![
+                    widget::text_input(
+                        "Select JAR file...",
+                        self.config.custom_jar
+                            .as_ref()
+                            .map(|cj| cj.jar_path.as_str())
+                            .unwrap_or_default()
+                    )
+                    .on_input(|t| Message::EditInstance(EditInstanceMessage::CustomJarPathChanged(t)))
+                    .width(Length::Fill),
+                    button_with_icon(icon_manager::folder(), "Browse", 14)
+                        .on_press(Message::EditInstance(EditInstanceMessage::CustomJarBrowse))
+                ]
+                .spacing(10),
+            ]
+            .spacing(10));
+        }
+
+        column.padding(10).spacing(10)
     }
 
     fn get_java_args_list<'a>(

--- a/quantum_launcher/src/message_update/edit_instance.rs
+++ b/quantum_launcher/src/message_update/edit_instance.rs
@@ -136,6 +136,49 @@ impl Launcher {
                     }
                 }
             }
+            EditInstanceMessage::CustomJarToggle(enabled) => {
+                if let State::Launch(MenuLaunch {
+                    edit_instance: Some(menu),
+                    ..
+                }) = &mut self.state
+                {
+                    if enabled {
+                        menu.config.custom_jar = Some(ql_core::json::instance_config::CustomJarConfig {
+                            jar_path: String::new(),
+                        });
+                    } else {
+                        menu.config.custom_jar = None;
+                    }
+                }
+            }
+            EditInstanceMessage::CustomJarPathChanged(path) => {
+                if let State::Launch(MenuLaunch {
+                    edit_instance: Some(menu),
+                    ..
+                }) = &mut self.state
+                {
+                    if let Some(custom_jar) = &mut menu.config.custom_jar {
+                        custom_jar.jar_path = path;
+                    }
+                }
+            }
+            EditInstanceMessage::CustomJarBrowse => {
+                if let Some(path) = rfd::FileDialog::new()
+                    .set_title("Select Custom Minecraft JAR")
+                    .add_filter("Java Archive", &["jar"])
+                    .pick_file()
+                {
+                    if let State::Launch(MenuLaunch {
+                        edit_instance: Some(menu),
+                        ..
+                    }) = &mut self.state
+                    {
+                        if let Some(custom_jar) = &mut menu.config.custom_jar {
+                            custom_jar.jar_path = path.to_string_lossy().to_string();
+                        }
+                    }
+                }
+            }
         }
         Ok(Task::none())
     }

--- a/quantum_launcher/src/state/message.rs
+++ b/quantum_launcher/src/state/message.rs
@@ -73,6 +73,9 @@ pub enum EditInstanceMessage {
     RenameApply,
     WindowWidthChanged(String),
     WindowHeightChanged(String),
+    CustomJarToggle(bool),
+    CustomJarPathChanged(String),
+    CustomJarBrowse,
 }
 
 #[derive(Debug, Clone)]

--- a/quantum_launcher/src/stylesheet/widgets.rs
+++ b/quantum_launcher/src/stylesheet/widgets.rs
@@ -381,9 +381,9 @@ impl widget::checkbox::Catalog for LauncherTheme {
         Box::new(|n, status| n.style_checkbox(status, None))
     }
 
-    fn style<'a>(
+    fn style(
         &self,
-        s: &<Self as widget::checkbox::Catalog>::Class<'a>,
+        s: &<Self as widget::checkbox::Catalog>::Class<'_>,
         status: widget::checkbox::Status,
     ) -> widget::checkbox::Style {
         s(self, status)


### PR DESCRIPTION

Closes #69 
## TL;DR
This PR adds support for using custom Minecraft client JAR files while maintaining compatibility with the existing asset system. Users can now specify alternative JAR files for instances, enabling support for modified clients, archived versions, and custom modded JARs.

##  Features Added

- **Custom JAR Configuration:** New `CustomJarConfig` struct in instance configuration
- **File Browser Integration:** Easy JAR file selection with native file dialog
- **Seamless Asset Handling:** Uses existing instance assets (no redownload required)
- **Clean UI Integration:** Toggle checkbox with intuitive file path input in Edit Instance screen
- **Backward Compatibility:** Existing instances continue working without changes


##  Use Cases Supported

- Omniarchive special versions (e.g., `a1.0.16_05.jar`)
- External client JARs not available through the launcher
- Custom modded clients with vanilla assets
- April Fools editions and special client JARs
- Development/testing with custom-built client JARs
<img width="1918" height="1103" alt="1" src="https://github.com/user-attachments/assets/400f8988-874b-42d2-bfae-a705018286d5" />
