### PR TITLE
Improvements to mod loaders support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ image = { version = "0.24", default-features = false, features = [
     "webp",
 ] }
 tempfile = "3"
+regex = "1"
 
 # [profile.dev]
 # opt-level = 1

--- a/changelogs/unreleased.md
+++ b/changelogs/unreleased.md
@@ -1,6 +1,9 @@
 # unreleased
 
 # Mods
+## Loaders
+- You can now install Legacy Fabric for Minecraft 1.3 - 1.13
+- (TODO) You can now install OrnitheMC (Fabric) for Minecraft b1.7 - 1.13
 ## UX
 - (TODO) Presets and text exporting (explained below) are now grouped together
   under a hamburger menu for easier access

--- a/crates/ql_core/Cargo.toml
+++ b/crates/ql_core/Cargo.toml
@@ -12,7 +12,7 @@ colored = { workspace = true }
 
 zip = { workspace = true }
 walkdir = { workspace = true }
-regex = "1"
+regex = { workspace = true }
 
 reqwest = { workspace = true }
 tokio = { workspace = true }

--- a/crates/ql_core/src/json/fabric.rs
+++ b/crates/ql_core/src/json/fabric.rs
@@ -10,13 +10,13 @@ pub struct FabricJSON {
     pub libraries: Vec<Library>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Arguments {
     pub jvm: Option<Vec<String>>,
     pub game: Option<Vec<String>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Library {
     pub name: String,
     pub url: String,
@@ -41,13 +41,11 @@ impl Library {
     pub fn get_url(&self) -> String {
         let parts: Vec<&str> = self.name.split(':').collect();
         format!(
-            "{}{}/{}/{}/{}-{}.jar",
+            "{}{}/{p1}/{p2}/{p1}-{p2}.jar",
             self.url,
             parts[0].replace('.', "/"),
-            parts[1],
-            parts[2],
-            parts[1],
-            parts[2],
+            p1 = parts[1],
+            p2 = parts[2],
         )
     }
 }

--- a/crates/ql_core/src/json/instance_config.rs
+++ b/crates/ql_core/src/json/instance_config.rs
@@ -16,7 +16,7 @@ pub enum JavaArgsMode {
     #[serde(rename = "disable")]
     Disable,
     /// Combine global arguments with instance arguments,
-    /// using both together.
+    /// using both together. (Default)
     #[serde(rename = "combine")]
     #[default]
     Combine,
@@ -68,48 +68,37 @@ pub struct InstanceConfigJson {
     /// - `"Quilt"`
     /// - `"NeoForge"`
     pub mod_type: String,
-    /// If you want to use your own Java installation
-    /// instead of the auto-installed one, specify
-    /// the path to the `java` executable here.
+    pub mod_type_info: Option<ModTypeInfo>,
+
+    /// Path to custom `java` binary. Uses auto-installed Java if `None`.
     pub java_override: Option<String>,
-    /// The amount of RAM in megabytes the instance should have.
+    /// Memory allocation in MB.
     pub ram_in_mb: usize,
-    /// **Default: `true`**
-    ///
-    /// - `true` (default): Show log output in launcher.
-    ///   May not show all log output, especially during a crash.
-    /// - `false`: Print raw, unformatted log output to the console (stdout).
-    ///   This is useful for debugging, but may be hard to read.
+    /// Show logs in launcher (`true`, default) or raw console output AKA `stdout`/`stderr` (`false`).
     pub enable_logger: Option<bool>,
-    /// This is an optional list of additional
-    /// arguments to pass to Java.
+
+    /// Extra JVM (Java) arguments.
     pub java_args: Option<Vec<String>>,
-    /// This is an optional list of additional
-    /// arguments to pass to the game.
+    /// Extra game arguments.
     pub game_args: Option<Vec<String>>,
-    /// DEPRECATED in v0.4.2
-    ///
-    /// This used to indicate whether a version
-    /// was downloaded from Omniarchive instead
-    /// of Mojang, in Quantum Launcher
+
+    /// Previously used to indicate if a version was downloaded from Omniarchive
     /// v0.3.1 - v0.4.1
     #[deprecated(since = "0.4.2", note = "migrated to BetterJSONs, so no longer needed")]
     pub omniarchive: Option<serde_json::Value>,
-    /// **Default: `false`**
+
+    /// Classic server mode. Default: `false`.
+    /// - `false` (default) if this is a client
+    ///   or a non-classic server
+    /// - `true` if this is a classic server
     ///
-    /// - `true`: the instance is a classic server.
-    /// - `false` (default): the instance is a client
-    ///   or a non-classic server (alpha, beta, release).
-    ///
-    /// This is stored because classic servers:
-    /// - Are downloaded differently (zip file to extract)
-    /// - Cannot be stopped by sending a `stop` command.
-    ///   (need to kill the process)
+    /// Affects download and shutdown behavior.
+    /// (classic servers come in ZIP files and
+    /// cannot be stopped through `stop` command)
     pub is_classic_server: Option<bool>,
-    /// **`false` for client instances, `true` for server installations**
-    ///
-    /// Added in v0.4.2
+    /// Whether this is a server installation (default `false`).
     pub is_server: Option<bool>,
+
     /// **Client Only**
     ///
     /// If true, then the Java Garbage Collector
@@ -141,34 +130,22 @@ pub struct InstanceConfigJson {
     /// - `-XX:MaxGCPauseMillis=50`
     /// - `-XX:G1HeapRegionSize=32M`
     pub do_gc_tuning: Option<bool>,
-    /// **Client Only**
-    ///
-    /// Whether to close the launcher upon
-    /// starting the game.
+
+    /// Whether to close launcher after
+    /// the client (game) starts.
     ///
     /// **Default: `false`**
     ///
-    /// This keeps *just the game* running
-    /// after you open it. However:
-    /// - The impact of keeping the launcher open
-    ///   is downright **negligible**. Quantum Launcher
-    ///   is **very** lightweight. You won't feel any
-    ///   difference even on slow computers
-    /// - By doing this you lose access to easy log viewing
-    ///   and the ability to easily kill the game process if stuck
-    ///
-    /// Ultimately if you want one less icon in your taskbar then go ahead.
+    /// Only enable this if you want one less
+    /// icon in your taskbar, as the impact of
+    /// leaving the launcher open is negligible
+    /// and a net positive.
     pub close_on_start: Option<bool>,
 
     pub global_settings: Option<GlobalSettings>,
 
-    /// Controls how this instance's Java arguments interact with global Java arguments.
-    ///
-    /// **Default: `JavaArgsMode::Fallback`**
-    ///
-    /// - `Fallback`: Use global args only when instance has no meaningful args (backward compatible)
-    /// - `Override`: Instance args completely replace global args (ignore global when instance has args)
-    /// - `Combine`: Global args are prepended to instance args (both are used together)
+    /// How this instance's Java arguments interact with global Java arguments.
+    /// Default: `Combine`. See [`JavaArgsMode`] for more info.
     pub java_args_mode: Option<JavaArgsMode>,
 }
 
@@ -290,6 +267,14 @@ impl InstanceConfigJson {
             }
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ModTypeInfo {
+    pub version: String,
+    /// If an unofficial implementation of the loader
+    /// was used, which one (eg: Legacy Fabric).
+    pub backend_implementation: Option<String>,
 }
 
 /// Settings that can both be set on a per-instance basis

--- a/crates/ql_instances/src/download/downloader.rs
+++ b/crates/ql_instances/src/download/downloader.rs
@@ -323,6 +323,7 @@ impl GameDownloader {
             omniarchive: None,
             global_settings: None,
             java_args_mode: None,
+            mod_type_info: None,
         };
         let config_json = serde_json::to_string(&config_json).json_to()?;
 

--- a/crates/ql_mod_manager/Cargo.toml
+++ b/crates/ql_mod_manager/Cargo.toml
@@ -24,4 +24,4 @@ thiserror = { workspace = true }
 
 image = { workspace = true }
 chrono = { workspace = true }
-regex = "1"
+regex = { workspace = true }

--- a/crates/ql_mod_manager/src/loaders/fabric/mod.rs
+++ b/crates/ql_mod_manager/src/loaders/fabric/mod.rs
@@ -18,15 +18,33 @@ mod uninstall;
 pub use uninstall::{uninstall, uninstall_client, uninstall_server};
 mod version_compare;
 
-const FABRIC_URL: &str = "https://meta.fabricmc.net/v2";
-const QUILT_URL: &str = "https://meta.quiltmc.org/v3";
+#[derive(Debug, Clone, Copy)]
+pub enum BackendType {
+    Fabric,
+    Quilt,
+    LegacyFabric,
+}
 
-async fn download_file_to_string(url: &str, is_quilt: bool) -> Result<String, RequestError> {
+impl BackendType {
+    pub fn get_url(self) -> &'static str {
+        match self {
+            BackendType::Fabric => "https://meta.fabricmc.net/v2",
+            BackendType::Quilt => "https://meta.quiltmc.org/v3",
+            BackendType::LegacyFabric => "https://meta.legacyfabric.net/v2",
+        }
+    }
+
+    pub fn is_quilt(self) -> bool {
+        matches!(self, BackendType::Quilt)
+    }
+}
+
+async fn download_file_to_string(url: &str, backend: BackendType) -> Result<String, RequestError> {
     file_utils::download_file_to_string(
         &format!(
             "{}{}{url}",
+            backend.get_url(),
             if url.starts_with('/') { "" } else { "/" },
-            if is_quilt { QUILT_URL } else { FABRIC_URL }
         ),
         false,
     )
@@ -36,22 +54,41 @@ async fn download_file_to_string(url: &str, is_quilt: bool) -> Result<String, Re
 pub async fn get_list_of_versions(
     instance: InstanceSelection,
     is_quilt: bool,
-) -> Result<Vec<FabricVersionListItem>, FabricInstallError> {
+) -> Result<(Vec<FabricVersionListItem>, BackendType), FabricInstallError> {
     async fn inner(
         version_json: &VersionDetails,
         is_quilt: bool,
-    ) -> Result<Vec<FabricVersionListItem>, JsonDownloadError> {
+    ) -> Result<(Vec<FabricVersionListItem>, BackendType), JsonDownloadError> {
+        let mut backend = if is_quilt {
+            BackendType::Quilt
+        } else {
+            BackendType::Fabric
+        };
         let version_list = download_file_to_string(
             &format!("/versions/loader/{}", version_json.get_id()),
-            is_quilt,
+            backend,
         )
         .await?;
-        let versions = serde_json::from_str(&version_list).json(version_list)?;
-        Ok(versions)
+        let mut versions: Vec<FabricVersionListItem> =
+            serde_json::from_str(&version_list).json(version_list)?;
+
+        if versions.is_empty() && !is_quilt {
+            backend = BackendType::LegacyFabric;
+
+            let version_list = download_file_to_string(
+                &format!("/versions/loader/{}", version_json.get_id()),
+                backend,
+            )
+            .await?;
+
+            versions = serde_json::from_str(&version_list).json(version_list)?;
+        }
+
+        Ok((versions, backend))
     }
 
     let version_json = VersionDetails::load(&instance).await?;
-    
+
     let mut result = inner(&version_json, is_quilt).await;
     if result.is_err() {
         for _ in 0..5 {
@@ -62,7 +99,14 @@ pub async fn get_list_of_versions(
                     code, ..
                 })) if code.as_u16() == 404 => {
                     // Unsupported version
-                    return Ok(Vec::new());
+                    return Ok((
+                        Vec::new(),
+                        if is_quilt {
+                            BackendType::Quilt
+                        } else {
+                            BackendType::Fabric
+                        },
+                    ));
                 }
                 Err(_) => {}
             }
@@ -76,9 +120,15 @@ pub async fn install_server(
     loader_version: String,
     server_name: String,
     progress: Option<&Sender<GenericProgress>>,
-    is_quilt: bool,
+    backend: BackendType,
 ) -> Result<(), FabricInstallError> {
-    let loader_name = if is_quilt { "Quilt" } else { "Fabric" };
+    // TODO: Add legacy fabric support for servers
+
+    let loader_name = if backend.is_quilt() {
+        "Quilt"
+    } else {
+        "Fabric"
+    };
     info!("Installing {loader_name} for server");
 
     if let Some(progress) = &progress {
@@ -95,8 +145,11 @@ pub async fn install_server(
     let json = VersionDetails::load_from_path(&server_dir).await?;
     let game_version = json.get_id();
 
-    let json_url = format!("/versions/loader/{game_version}/{loader_version}/server/json");
-    let json = download_file_to_string(&json_url, is_quilt).await?;
+    let json = download_file_to_string(
+        &format!("/versions/loader/{game_version}/{loader_version}/server/json"),
+        backend,
+    )
+    .await?;
 
     let json_path = server_dir.join("fabric.json");
     tokio::fs::write(&json_path, &json).await.path(json_path)?;
@@ -148,9 +201,13 @@ pub async fn install_client(
     loader_version: String,
     instance_name: String,
     progress: Option<&Sender<GenericProgress>>,
-    is_quilt: bool,
+    backend: BackendType,
 ) -> Result<(), FabricInstallError> {
-    let loader_name = if is_quilt { "Quilt" } else { "Fabric" };
+    let loader_name = if backend.is_quilt() {
+        "Quilt"
+    } else {
+        "Fabric"
+    };
 
     let instance_dir = LAUNCHER_DIR.join("instances").join(instance_name);
 
@@ -166,12 +223,15 @@ pub async fn install_client(
 
     let libraries_dir = instance_dir.join("libraries");
 
-    let json = VersionDetails::load_from_path(&instance_dir).await?;
-    let game_version = json.get_id();
+    let version_json = VersionDetails::load_from_path(&instance_dir).await?;
+    let game_version = version_json.get_id();
 
     let json_path = instance_dir.join("fabric.json");
-    let json_url = format!("/versions/loader/{game_version}/{loader_version}/profile/json");
-    let json = download_file_to_string(&json_url, is_quilt).await?;
+    let json = download_file_to_string(
+        &format!("/versions/loader/{game_version}/{loader_version}/profile/json"),
+        backend,
+    )
+    .await?;
     tokio::fs::write(&json_path, &json).await.path(json_path)?;
 
     let json: FabricJSON = serde_json::from_str(&json).json(json)?;
@@ -270,14 +330,15 @@ pub async fn install(
     loader_version: Option<String>,
     instance: InstanceSelection,
     progress: Option<&Sender<GenericProgress>>,
-    is_quilt: bool,
+    mut backend: BackendType,
 ) -> Result<(), FabricInstallError> {
     let loader_version = if let Some(n) = loader_version {
         n
     } else {
-        get_list_of_versions(instance.clone(), is_quilt)
-            .await?
-            .first()
+        let (list, new_backend) =
+            get_list_of_versions(instance.clone(), backend.is_quilt()).await?;
+        backend = new_backend;
+        list.first()
             .ok_or(FabricInstallError::NoVersionFound)?
             .loader
             .version
@@ -285,9 +346,9 @@ pub async fn install(
     };
     match instance {
         InstanceSelection::Instance(n) => {
-            install_client(loader_version, n, progress, is_quilt).await
+            install_client(loader_version, n, progress, backend).await
         }
-        InstanceSelection::Server(n) => install_server(loader_version, n, progress, is_quilt).await,
+        InstanceSelection::Server(n) => install_server(loader_version, n, progress, backend).await,
     }
 }
 

--- a/crates/ql_mod_manager/src/loaders/fabric/uninstall.rs
+++ b/crates/ql_mod_manager/src/loaders/fabric/uninstall.rs
@@ -47,7 +47,7 @@ pub async fn uninstall_server(server_name: String) -> Result<(), FabricInstallEr
         }
     }
 
-    change_instance_type(&server_dir, "Vanilla".to_owned()).await?;
+    change_instance_type(&server_dir, "Vanilla".to_owned(), None).await?;
     info!("Finished uninstalling fabric");
 
     Ok(())
@@ -81,7 +81,7 @@ pub async fn uninstall_client(instance_name: String) -> Result<(), FabricInstall
         }
     }
 
-    change_instance_type(&instance_dir, "Vanilla".to_owned()).await?;
+    change_instance_type(&instance_dir, "Vanilla".to_owned(), None).await?;
     Ok(())
 }
 

--- a/crates/ql_mod_manager/src/loaders/fabric/uninstall.rs
+++ b/crates/ql_mod_manager/src/loaders/fabric/uninstall.rs
@@ -63,18 +63,20 @@ pub async fn uninstall_client(instance_name: String) -> Result<(), FabricInstall
         let fabric_json = tokio::fs::read_to_string(&fabric_json_path)
             .await
             .path(&fabric_json_path)?;
-        let fabric_json: FabricJSON = serde_json::from_str(&fabric_json).json(fabric_json)?;
+        if let Ok(FabricJSON { libraries, .. }) =
+            serde_json::from_str(&fabric_json).json(fabric_json)
+        {
+            tokio::fs::remove_file(&fabric_json_path)
+                .await
+                .path(fabric_json_path)?;
 
-        tokio::fs::remove_file(&fabric_json_path)
-            .await
-            .path(fabric_json_path)?;
-
-        for library in &fabric_json.libraries {
-            let library_path = libraries_dir.join(library.get_path());
-            if library_path.exists() {
-                tokio::fs::remove_file(&library_path)
-                    .await
-                    .path(library_path)?;
+            for library in &libraries {
+                let library_path = libraries_dir.join(library.get_path());
+                if library_path.exists() {
+                    tokio::fs::remove_file(&library_path)
+                        .await
+                        .path(library_path)?;
+                }
             }
         }
     }

--- a/crates/ql_mod_manager/src/loaders/fabric/version_list.rs
+++ b/crates/ql_mod_manager/src/loaders/fabric/version_list.rs
@@ -226,7 +226,7 @@ pub async fn get_list_of_versions(
             try_backend(version, BackendType::OrnitheMC)
         )?;
 
-        return Ok(match (legacy_fabric.is_empty(), ornithe_mc.is_empty()) {
+        Ok(match (legacy_fabric.is_empty(), ornithe_mc.is_empty()) {
             (true, true) => VersionList::Unsupported,
             (true, false) => VersionList::OrnitheMC(ornithe_mc),
             (false, true) => VersionList::LegacyFabric(legacy_fabric),
@@ -234,7 +234,7 @@ pub async fn get_list_of_versions(
                 legacy_fabric,
                 ornithe_mc,
             },
-        });
+        })
     }
 
     let version_json = VersionDetails::load(&instance).await?;

--- a/crates/ql_mod_manager/src/loaders/fabric/version_list.rs
+++ b/crates/ql_mod_manager/src/loaders/fabric/version_list.rs
@@ -1,0 +1,265 @@
+use std::fmt::Display;
+
+use ql_core::{
+    json::VersionDetails, InstanceSelection, IntoJsonError, JsonDownloadError, RequestError,
+};
+use serde::Deserialize;
+
+use crate::loaders::fabric::{download_file_to_string, FabricInstallError};
+
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+pub struct FabricVersionListItem {
+    pub loader: FabricVersion,
+}
+
+impl Display for FabricVersionListItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.loader.version)
+    }
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+pub struct FabricVersion {
+    // pub separator: String,
+    // pub build: usize,
+    // pub maven: String,
+    pub version: String,
+    // pub stable: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BackendType {
+    Fabric,
+    Quilt,
+    LegacyFabric,
+    OrnitheMC,
+    CursedLegacy,
+    Babric,
+}
+
+impl BackendType {
+    pub fn get_url(self) -> &'static str {
+        match self {
+            BackendType::Fabric => "https://meta.fabricmc.net/v2",
+            BackendType::Quilt => "https://meta.quiltmc.org/v3",
+            BackendType::LegacyFabric => "https://meta.legacyfabric.net/v2",
+            BackendType::OrnitheMC => "https://meta.ornithemc.net/v2",
+            BackendType::Babric => "https://meta.babric.glass-launcher.net/v2",
+            BackendType::CursedLegacy => todo!(),
+        }
+    }
+
+    pub fn is_quilt(self) -> bool {
+        matches!(self, BackendType::Quilt)
+    }
+}
+
+impl Display for BackendType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                BackendType::Fabric => "Fabric",
+                BackendType::Quilt => "Quilt",
+                BackendType::LegacyFabric => "Fabric (Legacy)",
+                BackendType::OrnitheMC => "Fabric (OrnitheMC)",
+                BackendType::CursedLegacy => "Fabric (Cursed Legacy)",
+                BackendType::Babric => "Fabric (Babric)",
+            }
+        )
+    }
+}
+
+type List = Vec<FabricVersionListItem>;
+
+#[derive(Debug, Clone)]
+pub enum VersionList {
+    Beta173 {
+        ornithe_mc: List,
+        babric: List,
+        cursed_legacy: List,
+    },
+    Quilt(List),
+    Fabric(List),
+
+    LegacyFabric(List),
+    OrnitheMC(List),
+    Both {
+        legacy_fabric: List,
+        ornithe_mc: List,
+    },
+    Unsupported,
+}
+
+impl VersionList {
+    pub fn just_get_one(self) -> (List, BackendType) {
+        match self {
+            VersionList::Quilt(l) => (l, BackendType::Quilt),
+            VersionList::Fabric(l) => (l, BackendType::Fabric),
+            VersionList::LegacyFabric(l) => (l, BackendType::LegacyFabric),
+            VersionList::OrnitheMC(l) => (l, BackendType::OrnitheMC),
+
+            // Opinionated, feel free to tell me
+            // if there's a better choice
+            #[allow(unused)]
+            VersionList::Beta173 {
+                ornithe_mc,
+                babric,
+                cursed_legacy,
+            } => (babric, BackendType::Babric),
+            #[allow(unused)]
+            VersionList::Both {
+                legacy_fabric,
+                ornithe_mc,
+            } => (legacy_fabric, BackendType::LegacyFabric),
+            VersionList::Unsupported => (Vec::new(), BackendType::Fabric),
+        }
+    }
+
+    pub fn get_choices(&self) -> &'static [BackendType] {
+        match self {
+            VersionList::Quilt(_) => &[BackendType::Quilt],
+            VersionList::Fabric(_) => &[BackendType::Fabric],
+            VersionList::LegacyFabric(_) => &[BackendType::LegacyFabric],
+            VersionList::OrnitheMC(_) => &[BackendType::OrnitheMC],
+            VersionList::Unsupported => &[BackendType::Fabric],
+
+            #[allow(unused)]
+            VersionList::Beta173 {
+                ornithe_mc,
+                babric,
+                cursed_legacy,
+            } => &[
+                BackendType::OrnitheMC,
+                BackendType::Babric,
+                BackendType::CursedLegacy,
+            ],
+            #[allow(unused)]
+            VersionList::Both {
+                legacy_fabric,
+                ornithe_mc,
+            } => &[BackendType::LegacyFabric, BackendType::OrnitheMC],
+        }
+    }
+
+    pub fn get_specific(self, backend: BackendType) -> Option<Vec<FabricVersionListItem>> {
+        match (self, backend) {
+            (VersionList::Beta173 { ornithe_mc, .. }, BackendType::OrnitheMC) => Some(ornithe_mc),
+            (VersionList::Beta173 { cursed_legacy, .. }, BackendType::CursedLegacy) => {
+                Some(cursed_legacy)
+            }
+            (VersionList::Beta173 { babric, .. }, BackendType::Babric) => Some(babric),
+            (VersionList::Both { legacy_fabric, .. }, BackendType::LegacyFabric) => {
+                Some(legacy_fabric)
+            }
+            (VersionList::Both { ornithe_mc, .. }, BackendType::OrnitheMC) => Some(ornithe_mc),
+
+            (VersionList::Fabric(l), BackendType::Fabric)
+            | (VersionList::LegacyFabric(l), BackendType::LegacyFabric)
+            | (VersionList::OrnitheMC(l), BackendType::OrnitheMC)
+            | (VersionList::Quilt(l), BackendType::Quilt) => Some(l),
+
+            _ => None,
+        }
+    }
+
+    pub fn is_unsupported(&self) -> bool {
+        match self {
+            VersionList::Quilt(l)
+            | VersionList::Fabric(l)
+            | VersionList::LegacyFabric(l)
+            | VersionList::OrnitheMC(l) => l.is_empty(),
+
+            VersionList::Beta173 {
+                ornithe_mc,
+                babric,
+                cursed_legacy,
+            } => ornithe_mc.is_empty() && babric.is_empty() && cursed_legacy.is_empty(),
+            VersionList::Both {
+                legacy_fabric,
+                ornithe_mc,
+            } => legacy_fabric.is_empty() && ornithe_mc.is_empty(),
+            VersionList::Unsupported => true,
+        }
+    }
+}
+
+pub async fn get_list_of_versions(
+    instance: InstanceSelection,
+    is_quilt: bool,
+) -> Result<VersionList, FabricInstallError> {
+    async fn try_backend(version: &str, backend: BackendType) -> Result<List, JsonDownloadError> {
+        let version_list =
+            download_file_to_string(&format!("/versions/loader/{version}"), backend).await?;
+        let versions: List = serde_json::from_str(&version_list).json(version_list)?;
+        Ok(versions)
+    }
+
+    async fn inner(version: &str, is_quilt: bool) -> Result<VersionList, JsonDownloadError> {
+        if is_quilt {
+            let versions = try_backend(version, BackendType::Quilt).await?;
+            return Ok(VersionList::Quilt(versions));
+        }
+
+        let official_versions = try_backend(version, BackendType::Fabric).await?;
+        if !official_versions.is_empty() {
+            return Ok(VersionList::Fabric(official_versions));
+        }
+
+        if version == "b1.7.3" {
+            let (ornithe_mc, cursed_legacy, babric) = tokio::try_join!(
+                try_backend(version, BackendType::OrnitheMC),
+                try_backend(version, BackendType::CursedLegacy),
+                try_backend(version, BackendType::Babric),
+            )?;
+
+            return Ok(VersionList::Beta173 {
+                ornithe_mc,
+                babric,
+                cursed_legacy,
+            });
+        }
+
+        let (legacy_fabric, ornithe_mc) = tokio::try_join!(
+            try_backend(version, BackendType::LegacyFabric),
+            try_backend(version, BackendType::OrnitheMC)
+        )?;
+
+        return Ok(match (legacy_fabric.is_empty(), ornithe_mc.is_empty()) {
+            (true, true) => VersionList::Unsupported,
+            (true, false) => VersionList::OrnitheMC(ornithe_mc),
+            (false, true) => VersionList::LegacyFabric(legacy_fabric),
+            (false, false) => VersionList::Both {
+                legacy_fabric,
+                ornithe_mc,
+            },
+        });
+    }
+
+    let version_json = VersionDetails::load(&instance).await?;
+    let version = version_json.get_id();
+
+    let mut result = inner(version, is_quilt).await;
+    if result.is_err() {
+        for _ in 0..5 {
+            result = inner(version, is_quilt).await;
+            match &result {
+                Ok(_) => break,
+                Err(JsonDownloadError::RequestError(RequestError::DownloadError {
+                    code, ..
+                })) if code.as_u16() == 404 => {
+                    // Unsupported version
+                    return Ok(if is_quilt {
+                        VersionList::Quilt(Vec::new())
+                    } else {
+                        VersionList::Fabric(Vec::new())
+                    });
+                }
+                Err(_) => {}
+            }
+        }
+    }
+
+    result.map_err(FabricInstallError::from)
+}

--- a/crates/ql_mod_manager/src/loaders/forge/mod.rs
+++ b/crates/ql_mod_manager/src/loaders/forge/mod.rs
@@ -3,6 +3,7 @@ use ql_core::{
     do_jobs, err, file_utils, info,
     json::{
         forge::{JsonDetails, JsonDetailsLibrary, JsonInstallProfile, JsonVersions},
+        instance_config::ModTypeInfo,
         VersionDetails,
     },
     no_window, pt, GenericProgress, InstanceSelection, IntoIoError, IntoJsonError, IoError,
@@ -30,9 +31,12 @@ pub use uninstall::{uninstall, uninstall_client, uninstall_server};
 
 struct ForgeInstaller {
     f_progress: Option<Sender<ForgeInstallProgress>>,
+
+    version: String,
     norm_forge_version: String,
     short_version: String,
     major_version: usize,
+
     instance_dir: PathBuf,
     forge_dir: PathBuf,
     is_server: bool,
@@ -103,9 +107,12 @@ impl ForgeInstaller {
 
         Ok(Self {
             f_progress,
+
+            version,
             norm_forge_version,
             short_version,
             major_version,
+
             instance_dir,
             forge_dir,
             is_server: instance.is_server(),
@@ -602,7 +609,15 @@ pub async fn install_client(
     .await
     .path(json_path)?;
 
-    change_instance_type(&installer.instance_dir, "Forge".to_owned()).await?;
+    change_instance_type(
+        &installer.instance_dir,
+        "Forge".to_owned(),
+        Some(ModTypeInfo {
+            version: installer.version.clone(),
+            backend_implementation: None,
+        }),
+    )
+    .await?;
 
     installer.remove_lock().await?;
     info!("Finished installing forge");

--- a/crates/ql_mod_manager/src/loaders/forge/server.rs
+++ b/crates/ql_mod_manager/src/loaders/forge/server.rs
@@ -1,4 +1,4 @@
-use ql_core::{InstanceSelection, IntoIoError};
+use ql_core::{json::instance_config::ModTypeInfo, InstanceSelection, IntoIoError};
 
 use crate::loaders::{change_instance_type, forge::ForgeInstaller};
 
@@ -36,7 +36,15 @@ pub async fn install_server(
     installer.delete("ForgeInstaller.java").await?;
     installer.delete("ForgeInstaller.class").await?;
 
-    change_instance_type(&installer.instance_dir, "Forge".to_owned()).await?;
+    change_instance_type(
+        &installer.instance_dir,
+        "Forge".to_owned(),
+        Some(ModTypeInfo {
+            version: installer.version.clone(),
+            backend_implementation: None,
+        }),
+    )
+    .await?;
     installer.remove_lock().await?;
 
     Ok(())

--- a/crates/ql_mod_manager/src/loaders/forge/uninstall.rs
+++ b/crates/ql_mod_manager/src/loaders/forge/uninstall.rs
@@ -23,13 +23,13 @@ pub async fn uninstall_client(instance: &str) -> Result<(), ForgeInstallError> {
             .path(forge_dir)?;
     }
 
-    change_instance_type(&instance_dir, "Vanilla".to_owned()).await?;
+    change_instance_type(&instance_dir, "Vanilla".to_owned(), None).await?;
     Ok(())
 }
 
 pub async fn uninstall_server(instance: &str) -> Result<(), ForgeInstallError> {
     let instance_dir = LAUNCHER_DIR.join("servers").join(instance);
-    change_instance_type(&instance_dir, "Vanilla".to_owned()).await?;
+    change_instance_type(&instance_dir, "Vanilla".to_owned(), None).await?;
 
     if let Some(forge_shim_file) = find_forge_shim_file(&instance_dir).await {
         tokio::fs::remove_file(&forge_shim_file)

--- a/crates/ql_mod_manager/src/loaders/mod.rs
+++ b/crates/ql_mod_manager/src/loaders/mod.rs
@@ -8,8 +8,9 @@ use std::{
 
 use forge::ForgeInstallProgress;
 use ql_core::{
-    json::InstanceConfigJson, GenericProgress, InstanceSelection, IntoIoError, IntoJsonError,
-    IntoStringError, JsonFileError, Loader, Progress,
+    json::{instance_config::ModTypeInfo, InstanceConfigJson},
+    GenericProgress, InstanceSelection, IntoIoError, IntoJsonError, IntoStringError, JsonFileError,
+    Loader, Progress,
 };
 
 pub mod fabric;
@@ -21,10 +22,12 @@ pub mod paper;
 async fn change_instance_type(
     instance_dir: &Path,
     instance_type: String,
+    extras: Option<ModTypeInfo>,
 ) -> Result<(), JsonFileError> {
     let mut config = InstanceConfigJson::read_from_dir(instance_dir).await?;
 
     config.mod_type = instance_type;
+    config.mod_type_info = extras;
 
     let config = serde_json::to_string(&config).json_to()?;
     let config_path = instance_dir.join("config.json");

--- a/crates/ql_mod_manager/src/loaders/mod.rs
+++ b/crates/ql_mod_manager/src/loaders/mod.rs
@@ -49,14 +49,25 @@ pub async fn install_specified_loader(
 ) -> Result<LoaderInstallResult, String> {
     match loader {
         Loader::Fabric => {
-            fabric::install(specified_version, instance, progress.as_deref(), false)
-                .await
-                .strerr()?;
+            // TODO: Add legacy fabric support
+            fabric::install(
+                specified_version,
+                instance,
+                progress.as_deref(),
+                fabric::BackendType::Fabric,
+            )
+            .await
+            .strerr()?;
         }
         Loader::Quilt => {
-            fabric::install(specified_version, instance, progress.as_deref(), true)
-                .await
-                .strerr()?;
+            fabric::install(
+                specified_version,
+                instance,
+                progress.as_deref(),
+                fabric::BackendType::Quilt,
+            )
+            .await
+            .strerr()?;
         }
 
         Loader::Forge => {

--- a/crates/ql_mod_manager/src/loaders/neoforge.rs
+++ b/crates/ql_mod_manager/src/loaders/neoforge.rs
@@ -1,7 +1,9 @@
 use chrono::DateTime;
 use ql_core::{
-    file_utils, info, json::VersionDetails, no_window, pt, GenericProgress, InstanceSelection,
-    IntoIoError, IntoJsonError, IoError, CLASSPATH_SEPARATOR, REGEX_SNAPSHOT,
+    file_utils, info,
+    json::{instance_config::ModTypeInfo, VersionDetails},
+    no_window, pt, GenericProgress, InstanceSelection, IntoIoError, IntoJsonError, IoError,
+    CLASSPATH_SEPARATOR, REGEX_SNAPSHOT,
 };
 use ql_java_handler::{get_java_binary, JavaVersion, JAVA};
 use serde::Deserialize;
@@ -68,7 +70,15 @@ pub async fn install(
 
     info!("Finished installing NeoForge");
 
-    change_instance_type(&instance_dir, "NeoForge".to_owned()).await?;
+    change_instance_type(
+        &instance_dir,
+        "NeoForge".to_owned(),
+        Some(ModTypeInfo {
+            version: neoforge_version,
+            backend_implementation: None,
+        }),
+    )
+    .await?;
 
     Ok(())
 }

--- a/crates/ql_mod_manager/src/loaders/optifine.rs
+++ b/crates/ql_mod_manager/src/loaders/optifine.rs
@@ -140,7 +140,7 @@ pub async fn install(
     run_hook(&new_installer_path, &optifine_path).await?;
 
     download_libraries(&instance_name, &dot_minecraft_path, progress_sender).await?;
-    change_instance_type(&instance_path, "OptiFine".to_owned()).await?;
+    change_instance_type(&instance_path, "OptiFine".to_owned(), None).await?;
     send_progress(progress_sender, OptifineInstallProgress::P5Done);
     pt!("Finished installing OptiFine");
 
@@ -166,7 +166,7 @@ pub async fn uninstall(instance_name: String) -> Result<(), OptifineError> {
             .path(optifine_path)?;
     }
 
-    change_instance_type(&instance_path, "Vanilla".to_owned()).await?;
+    change_instance_type(&instance_path, "Vanilla".to_owned(), None).await?;
 
     let dot_minecraft_path = instance_path.join(".minecraft");
     let libraries_path = dot_minecraft_path.join("libraries");

--- a/crates/ql_packager/src/multimc.rs
+++ b/crates/ql_packager/src/multimc.rs
@@ -8,6 +8,7 @@ use ql_core::{
     err, file_utils, info, json::InstanceConfigJson, GenericProgress, InstanceSelection,
     IntoIoError, IntoJsonError, ListEntry,
 };
+use ql_mod_manager::loaders::fabric;
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 
@@ -65,7 +66,12 @@ pub async fn import(
                     Some(component.cachedVersion.clone()),
                     instance_selection.clone(),
                     sender.as_deref(),
-                    name == "Quilt",
+                    // TODO: Add legacy fabric support
+                    if name == "Quilt" {
+                        fabric::BackendType::Quilt
+                    } else {
+                        fabric::BackendType::Fabric
+                    },
                 )
                 .await?;
             }

--- a/crates/ql_servers/src/create.rs
+++ b/crates/ql_servers/src/create.rs
@@ -122,6 +122,7 @@ async fn write_config(
         close_on_start: None,
         global_settings: None,
         java_args_mode: None,
+        mod_type_info: None,
     };
     let server_config_path = server_dir.join("config.json");
     tokio::fs::write(

--- a/quantum_launcher/src/menu_renderer/mods/install_loader.rs
+++ b/quantum_launcher/src/menu_renderer/mods/install_loader.rs
@@ -157,7 +157,7 @@ impl MenuInstallFabric {
                     fabric::VersionList::Quilt(l)
                     | fabric::VersionList::Fabric(l)
                     | fabric::VersionList::LegacyFabric(l)
-                    | fabric::VersionList::OrnitheMC(l) => version_list(&l, fabric_version),
+                    | fabric::VersionList::OrnitheMC(l) => version_list(l, fabric_version),
 
                     fabric::VersionList::Beta173 {
                         ornithe_mc,

--- a/quantum_launcher/src/menu_renderer/mods/install_loader.rs
+++ b/quantum_launcher/src/menu_renderer/mods/install_loader.rs
@@ -114,12 +114,16 @@ impl MenuInstallFabric {
                 ]
             }
             MenuInstallFabric::Loaded {
-                is_quilt,
+                backend,
                 fabric_version,
                 fabric_versions,
                 progress,
             } => {
-                let loader_name = if *is_quilt { "Quilt" } else { "Fabric" };
+                let loader_name = if backend.is_quilt() {
+                    "Quilt"
+                } else {
+                    "Fabric"
+                };
 
                 if let Some(progress) = progress {
                     widget::column!(

--- a/quantum_launcher/src/message_update/mod.rs
+++ b/quantum_launcher/src/message_update/mod.rs
@@ -44,16 +44,16 @@ impl Launcher {
                 }
             }
             InstallFabricMessage::VersionsLoaded(result) => match result {
-                Ok((list, backend)) => {
+                Ok(list) => {
                     if let State::InstallFabric(menu) = &mut self.state {
-                        *menu = if let Some(first) = list.first().cloned() {
+                        let (regular_list, backend) = list.clone().just_get_one();
+                        *menu = if let (false, Some(first)) =
+                            (list.is_unsupported(), regular_list.first())
+                        {
                             MenuInstallFabric::Loaded {
                                 backend,
                                 fabric_version: first.loader.version.clone(),
-                                fabric_versions: list
-                                    .iter()
-                                    .map(|ver| ver.loader.version.clone())
-                                    .collect(),
+                                fabric_versions: list,
                                 progress: None,
                             }
                         } else {
@@ -63,6 +63,24 @@ impl Launcher {
                 }
                 Err(err) => self.set_error(err),
             },
+            InstallFabricMessage::ChangeBackend(b) => {
+                if let State::InstallFabric(MenuInstallFabric::Loaded {
+                    backend,
+                    fabric_version,
+                    fabric_versions,
+                    ..
+                }) = &mut self.state
+                {
+                    *backend = b;
+                    if let Some(n) = fabric_versions
+                        .clone()
+                        .get_specific(b)
+                        .and_then(|n| n.first().cloned())
+                    {
+                        *fabric_version = n.loader.version;
+                    }
+                }
+            }
             InstallFabricMessage::ButtonClicked => {
                 if let State::InstallFabric(MenuInstallFabric::Loaded {
                     fabric_version,

--- a/quantum_launcher/src/message_update/mod.rs
+++ b/quantum_launcher/src/message_update/mod.rs
@@ -44,13 +44,13 @@ impl Launcher {
                 }
             }
             InstallFabricMessage::VersionsLoaded(result) => match result {
-                Ok(list_of_versions) => {
+                Ok((list, backend)) => {
                     if let State::InstallFabric(menu) = &mut self.state {
-                        *menu = if let Some(first) = list_of_versions.first().cloned() {
+                        *menu = if let Some(first) = list.first().cloned() {
                             MenuInstallFabric::Loaded {
-                                is_quilt: menu.is_quilt(),
+                                backend,
                                 fabric_version: first.loader.version.clone(),
-                                fabric_versions: list_of_versions
+                                fabric_versions: list
                                     .iter()
                                     .map(|ver| ver.loader.version.clone())
                                     .collect(),
@@ -67,7 +67,7 @@ impl Launcher {
                 if let State::InstallFabric(MenuInstallFabric::Loaded {
                     fabric_version,
                     progress,
-                    is_quilt,
+                    backend,
                     ..
                 }) = &mut self.state
                 {
@@ -76,14 +76,14 @@ impl Launcher {
                     let loader_version = fabric_version.clone();
 
                     let instance_name = self.selected_instance.clone().unwrap();
-                    let is_quilt = *is_quilt;
+                    let backend = *backend;
                     return Task::perform(
                         async move {
                             loaders::fabric::install(
                                 Some(loader_version),
                                 instance_name,
                                 Some(&sender),
-                                is_quilt,
+                                backend,
                             )
                             .await
                         },

--- a/quantum_launcher/src/state/menu.rs
+++ b/quantum_launcher/src/state/menu.rs
@@ -234,7 +234,7 @@ pub enum MenuInstallFabric {
     Loaded {
         backend: loaders::fabric::BackendType,
         fabric_version: String,
-        fabric_versions: Vec<String>,
+        fabric_versions: loaders::fabric::VersionList,
         progress: Option<ProgressBar<GenericProgress>>,
     },
     Unsupported(bool),

--- a/quantum_launcher/src/state/menu.rs
+++ b/quantum_launcher/src/state/menu.rs
@@ -12,7 +12,7 @@ use ql_core::{
     SelectedMod, StoreBackendType,
 };
 use ql_mod_manager::{
-    loaders::{forge::ForgeInstallProgress, optifine::OptifineInstallProgress},
+    loaders::{self, forge::ForgeInstallProgress, optifine::OptifineInstallProgress},
     store::{CurseforgeNotAllowed, ModConfig, ModIndex, QueryType, RecommendedMod, SearchResult},
 };
 
@@ -232,7 +232,7 @@ pub enum MenuInstallFabric {
         _loading_handle: iced::task::Handle,
     },
     Loaded {
-        is_quilt: bool,
+        backend: loaders::fabric::BackendType,
         fabric_version: String,
         fabric_versions: Vec<String>,
         progress: Option<ProgressBar<GenericProgress>>,
@@ -244,8 +244,8 @@ impl MenuInstallFabric {
     pub fn is_quilt(&self) -> bool {
         match self {
             MenuInstallFabric::Loading { is_quilt, .. }
-            | MenuInstallFabric::Loaded { is_quilt, .. }
             | MenuInstallFabric::Unsupported(is_quilt) => *is_quilt,
+            MenuInstallFabric::Loaded { backend, .. } => backend.is_quilt(),
         }
     }
 }

--- a/quantum_launcher/src/state/message.rs
+++ b/quantum_launcher/src/state/message.rs
@@ -17,7 +17,7 @@ use ql_instances::{
     UpdateCheckInfo,
 };
 use ql_mod_manager::{
-    loaders::{self, fabric::FabricVersionListItem},
+    loaders::fabric,
     store::{CurseforgeNotAllowed, ImageResult, ModIndex, QueryType, RecommendedMod, SearchResult},
 };
 use tokio::process::Child;
@@ -28,9 +28,10 @@ use super::{LaunchTabId, LauncherSettingsTab, LicenseTab, Res};
 pub enum InstallFabricMessage {
     End(Res),
     VersionSelected(String),
-    VersionsLoaded(Res<(Vec<FabricVersionListItem>, loaders::fabric::BackendType)>),
+    VersionsLoaded(Res<fabric::VersionList>),
     ButtonClicked,
     ScreenOpen { is_quilt: bool },
+    ChangeBackend(fabric::BackendType),
 }
 
 #[derive(Debug, Clone)]

--- a/quantum_launcher/src/state/message.rs
+++ b/quantum_launcher/src/state/message.rs
@@ -17,7 +17,7 @@ use ql_instances::{
     UpdateCheckInfo,
 };
 use ql_mod_manager::{
-    loaders::fabric::FabricVersionListItem,
+    loaders::{self, fabric::FabricVersionListItem},
     store::{CurseforgeNotAllowed, ImageResult, ModIndex, QueryType, RecommendedMod, SearchResult},
 };
 use tokio::process::Child;
@@ -28,7 +28,7 @@ use super::{LaunchTabId, LauncherSettingsTab, LicenseTab, Res};
 pub enum InstallFabricMessage {
     End(Res),
     VersionSelected(String),
-    VersionsLoaded(Res<Vec<FabricVersionListItem>>),
+    VersionsLoaded(Res<(Vec<FabricVersionListItem>, loaders::fabric::BackendType)>),
     ButtonClicked,
     ScreenOpen { is_quilt: bool },
 }


### PR DESCRIPTION
This PR aims to implement the following things (incomplete)

# Alternate fabric implementations
While fabric isn't officially supported for older Minecraft versions,
there are unofficial implementations.

- [x] Legacy Fabric
- [x] OrnitheMC
- [x] Babric
- [ ] Cursed Legacy

If multiple implementations are available for an instance, you
get the option to choose between them

# Other
- [x] Add metadata related to the version and implementation of a mod loader,
  to instance config JSON
- [x] Clean up doc comments in instance config JSON
- [ ] Add mod loader support to the test suite