### PR TITLE
Fix: “Add Java argument” was adding to Game arguments

### DIFF
--- a/quantum_launcher/src/message_update/edit_instance.rs
+++ b/quantum_launcher/src/message_update/edit_instance.rs
@@ -107,8 +107,9 @@ impl Launcher {
                 }
             }
             EditInstanceMessage::JavaArgsAdd => {
-                iflet_config!(&mut self.state, get, game_args, {
-                    game_args.push(String::new());
+                // Bugfix: Add new argument to Java args (was incorrectly adding to game_args)
+                iflet_config!(&mut self.state, get, java_args, {
+                    java_args.push(String::new());
                 });
             }
             EditInstanceMessage::JavaArgEdit(msg, idx) => {

--- a/quantum_launcher/src/message_update/edit_instance.rs
+++ b/quantum_launcher/src/message_update/edit_instance.rs
@@ -107,7 +107,6 @@ impl Launcher {
                 }
             }
             EditInstanceMessage::JavaArgsAdd => {
-                // Bugfix: Add new argument to Java args (was incorrectly adding to game_args)
                 iflet_config!(&mut self.state, get, java_args, {
                     java_args.push(String::new());
                 });


### PR DESCRIPTION
Clicking “Add” under the Java arguments list added a new Game argument instead. 

