### PR TITLE
moves autoupdate into a default feature

### DIFF
--- a/quantum_launcher/Cargo.toml
+++ b/quantum_launcher/Cargo.toml
@@ -20,9 +20,11 @@ build = "build.rs"
 embed-resource = "3"
 
 [features]
-default = ["wgpu", "tiny_skia"]
+default = ["wgpu", "tiny_skia", "auto_update"]
 wgpu = ["iced/wgpu"]
 tiny_skia = ["iced/tiny-skia"]
+# checking for updates, autoupdater
+auto_update = []
 
 debug = ["iced/debug"]
 simulate_linux_arm64 = ["ql_instances/simulate_linux_arm64"]

--- a/quantum_launcher/src/message_handler/mod.rs
+++ b/quantum_launcher/src/message_handler/mod.rs
@@ -499,7 +499,7 @@ impl Launcher {
             *drag_and_drop_hovered = is_hovered;
         }
     }
-
+    #[cfg(feature = "auto_update")]
     pub fn update_download_start(&mut self) -> Task<Message> {
         if let State::UpdateFound(MenuLauncherUpdate { url, progress, .. }) = &mut self.state {
             let (sender, update_receiver) = std::sync::mpsc::channel();

--- a/quantum_launcher/src/update.rs
+++ b/quantum_launcher/src/update.rs
@@ -189,6 +189,7 @@ impl Launcher {
                     };
                 }
             },
+            #[cfg(feature = "auto_update")]
             Message::UpdateCheckResult(Ok(info)) => match info {
                 UpdateCheckInfo::UpToDate => {
                     info_no_log!("Launcher is latest version. No new updates");
@@ -200,7 +201,11 @@ impl Launcher {
                     });
                 }
             },
+            #[cfg(feature = "auto_update")]
             Message::UpdateDownloadStart => return self.update_download_start(),
+            #[cfg(not(feature = "auto_update"))]
+            Message::UpdateDownloadStart | Message::UpdateCheckResult(_) => return Task::none(),
+
             Message::LauncherSettings(msg) => return self.update_launcher_settings(msg),
 
             Message::InstallOptifine(msg) => return self.update_install_optifine(msg),


### PR DESCRIPTION
moves the update check and auto-updater into a default feature
useful for packaging where auto-updating could interfere with the package manager's state 