### PR TITLE
flake: rename the main-program

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,7 +101,7 @@
         meta = with pkgs.lib; {
           description = cargoToml.package.description;
           homepage = cargoToml.package.homepage;
-          mainProgram = cargoToml.package.name;
+          mainProgram = "quantum-launcher";
           license = licenses.gpl3Only;
         };
 


### PR DESCRIPTION
This pull request makes a small change to the `flake.nix` file to update the main program name to `"quantum-launcher"` for package metadata.